### PR TITLE
fix(types): undo wrong eslint --fix on analysisData ref

### DIFF
--- a/src/components/Print/Chapters/FoundationRiskChapter.vue
+++ b/src/components/Print/Chapters/FoundationRiskChapter.vue
@@ -39,7 +39,7 @@ interface CompletedFieldDataWithIcon extends CompletedFieldData {
 
 const fieldsWithDataAndIcons: ComputedRef<Record<string, CompletedFieldDataWithIcon>> = computed(() => {
   const fieldsConfig = applyContextToFieldDataConfigs({
-    source: analysisData.value || {},
+    source: analysisData,
     labels: riskFieldLabels,
     configs: [
       new FieldDataConfig({ group: 'drystand', name: 'drystandRisk' }),


### PR DESCRIPTION
## Summary
Hotfix for the DO build failure on \`main\` after PR #20.

The ESLint \`--fix\` in 150e499 turned \`source: analysisData || {}\` into \`source: analysisData.value || {}\` — unwrapping the ref. The function expects \`MaybeRefOrGetter<IEnumMethods>\`, which accepts the ref form directly. Unwrapping made the type \`IAnalysis | {}\`, which doesn't fit.

TS 5.8 + vue-tsc 2 was lenient enough to accept the auto-fixed code; TS 6 + vue-tsc 3 caught it on DO. I missed it locally because of a PIPESTATUS bug — \`vue-tsc … | tail … ; echo \$?\` reads tail's exit code, not vue-tsc's.

Pass the ref directly without the dead-code \`|| {}\` (refs are always truthy).

## Test plan
- [x] \`pnpm exec vue-tsc\` clean (PIPESTATUS verified)
- [x] \`pnpm run build\` succeeds
- [ ] DO build green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)