### PR TITLE
fix(api): subsidence call should hit /subsidence/historic

### DIFF
--- a/src/services/api/building.ts
+++ b/src/services/api/building.ts
@@ -133,7 +133,7 @@ export const getAllReportDataByBuildingId = async (buildingId: string): Promise<
 
 
 export const getSubsidenceByBuildingId = async (buildingId: string): Promise<ISubsidence[]> => {
-  return await get({ endpoint: `/product/${buildingId}/subsidence` })
+  return await get({ endpoint: `/product/${buildingId}/subsidence/historic` })
 }
 
 export default {


### PR DESCRIPTION
## Summary
Hotfix for the blank-page report after Phase 2 (#22).

The TS API has two subsidence endpoints under \`/api/product/:building_id\`:
- \`/subsidence\` — single latest measurement, **throws 404 on missing**
- \`/subsidence/historic\` — time-series array, returns \`[]\` on missing

Report's \`getSubsidenceByBuildingId\` returns \`ISubsidence[]\` and is used by the displacement chart, which needs the time series. WebFront's analogous call site uses \`/subsidence/historic\` for the same chart. Phase 2 mapped to the wrong one — most buildings have no exact-match row, so the 404 cascaded into a blank page (every data store in the Report must succeed before \`PDF.vue\`'s \`hasAllBuildingInformation\` gate flips true).

## Known follow-up (separate PR)
The Report's "all-or-nothing" rendering is brittle: any single 404 (e.g. building with no recovery reports, no inquiries, no incidents) blanks the whole page. Should treat a 404 as "retrieved with empty data" instead. Out of scope for this hotfix — this PR just unblocks the subsidence path.

## Test plan
- [x] \`pnpm exec vue-tsc\` clean (PIPESTATUS-checked)
- [x] \`pnpm run build\` clean
- [ ] After deploy: re-test the same building_id that was blank → should now render

🤖 Generated with [Claude Code](https://claude.com/claude-code)