### PR TITLE
chore(lint): Phase 1c — clean up the 48 remaining lint errors

### DIFF
--- a/src/components/Charts/BarChart.vue
+++ b/src/components/Charts/BarChart.vue
@@ -4,9 +4,9 @@ import { onMounted, ref, watch } from 'vue';
 
 import { CHART_COLORS } from '@/config';
 import Chart from 'chart.js/auto';
-import gradient from 'chartjs-plugin-gradient';
+import gradientPlugin from 'chartjs-plugin-gradient';
 
-Chart.register(gradient)
+Chart.register(gradientPlugin)
 
 const props = withDefaults(defineProps<{
   title?: string,
@@ -26,8 +26,8 @@ const props = withDefaults(defineProps<{
   gradient: false
 })
 
-// @ts-ignore: No time to deep dive into all the TS particulars of Chart.js
-let chart: any|null = null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let chart: any | null = null
 
 // Reference to Chart canvas element
 const canvas = ref<HTMLCanvasElement>();
@@ -68,7 +68,7 @@ const createChart = function createChart(
             borderColor: borderColors,
             borderWidth: 1,
 
-            // @ts-ignore
+            // @ts-expect-error gradient option provided by chartjs-plugin-gradient, not in Chart.js types
             gradient: props.gradient ? {
               backgroundColor: {
                 axis: 'y',

--- a/src/components/Charts/PieChart.vue
+++ b/src/components/Charts/PieChart.vue
@@ -17,8 +17,8 @@ const props = withDefaults(defineProps<{
   backgroundColors: () => Object.values(CHART_COLORS)
 })
 
-// @ts-ignore: No time to deep dive into all the TS particulars of Chart.js
-let chart: any|null = null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let chart: any | null = null
 
 // Reference to Chart canvas element
 const canvas = ref<HTMLCanvasElement>();

--- a/src/components/Charts/ScatterChart.vue
+++ b/src/components/Charts/ScatterChart.vue
@@ -29,8 +29,8 @@ const props = withDefaults(defineProps<{
   backgroundColors: () => Object.values(CHART_COLORS)
 })
 
-// @ts-ignore: No time to deep dive into all the TS particulars of Chart.js
-let chart: any|null = null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let chart: any | null = null
 
 // Reference to Chart canvas element
 const canvas = ref<HTMLCanvasElement>();
@@ -55,7 +55,7 @@ const createChart = function createChart(
             backgroundColor: backgroundColors,
             borderColor: borderColors,
             borderWidth: 1,
-            // @ts-ignore
+            // @ts-expect-error trendlineLinear option provided by chartjs-plugin-trendline, not in Chart.js types
             trendlineLinear: {
               colorMin: "#17a4ea",
 		          colorMax: "#17a4ea",
@@ -84,8 +84,8 @@ const createChart = function createChart(
             // beginAtZero: true,
             ticks: {
               color: '#808c99',
-              //@ts-ignore - TS wants a number, we want to show a date string, which does work just fine
-              callback: function(value: number, index, ticks) {
+              //@ts-expect-error - TS wants a number, we want to show a date string, which does work just fine
+              callback: function(value: number) {
                 return (new Date(value)).toLocaleDateString('nl-NL', { 
                   year: 'numeric',
                   month: 'short',
@@ -105,6 +105,7 @@ const createChart = function createChart(
           tooltip: {
             callbacks: {
               // any to avoid TS issue without having to create an interface for the whole thing
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               label: function(context: any) {
                 return `${(new Date(context.raw.x)).toLocaleDateString('nl-NL')}: ${(context.raw.y)} mm`
               }

--- a/src/components/Charts/StatisticsModal.vue
+++ b/src/components/Charts/StatisticsModal.vue
@@ -17,7 +17,7 @@ const { buildingId } = storeToRefs(useBuildingStore())
 const { getStatisticsDataByBuildingId } = useStatisticsStore()
 const { showStatisticsModal, statisticsGraph } = storeToRefs(useStatisticsStore())
 
-const emit = defineEmits(['close'])
+defineEmits(['close'])
 
 interface IComponents {
     [key: string]: Component
@@ -252,7 +252,7 @@ const backgroundColors = computed(() => {
     case 'foundationTypeDistribution': 
       return ['#7f8fa4', '#c9b441', '#7b2a2d', '#ce0015', '#ffcc69']
 
-    case 'foundationRiskDistribution':
+    case 'foundationRiskDistribution': {
       const riskColorMap = {
         'A': '#28CC8B',
         'B': '#A7DDB7',
@@ -262,8 +262,9 @@ const backgroundColors = computed(() => {
       }
 
       return labels.value
-        // @ts-ignore - things became too complex for TS to evaluate properly
+        // @ts-expect-error labels.value is string[] | number[]; for risk view it's always string[]
         .map((label: string) => (riskColorMap[label as keyof typeof riskColorMap] || ''))
+    }
   }
 
   return Object.values(CHART_TRANSPARENT_COLORS)

--- a/src/components/Common/Mapbox/MapBox.vue
+++ b/src/components/Common/Mapbox/MapBox.vue
@@ -56,10 +56,10 @@ const loadMapbox = function() {
   }
 
   map = new mapboxSDK.Map(
-    Object.assign(options, {
+    Object.assign({}, options, {
       container: mapcontainer.value,
       preserveDrawingBuffer: true // Enables export to png
-    }, 
+    },
     // Do not override style from options with an empty string
     mapStyle && mapStyle !== '' ? { style: mapStyle } : {})
   )

--- a/src/components/Print/Chapters/ConstructionYearChapter.vue
+++ b/src/components/Print/Chapters/ConstructionYearChapter.vue
@@ -97,7 +97,7 @@ const onLoad = async function onLoad({ map }: { map: Map }) {
   )
 
   // Add incident layer
-  // @ts-ignore
+  // @ts-expect-error JSON layer config has wider shape than mapbox LayerSpecification typing
   const layerSpecification: LayerSpecification = (await import('../../../config/layers/construction-year.json')).default
   map.addLayer(layerSpecification)
   map.setLayoutProperty('construction-year', 'visibility', 'visible')

--- a/src/components/Print/Chapters/FoundationRiskChapter.vue
+++ b/src/components/Print/Chapters/FoundationRiskChapter.vue
@@ -183,7 +183,7 @@ const graphData = computed(() => {
               op optrekkend vocht. Via poreuze bouwmaterialen - zoals bakstenen en metselmortel - wordt vocht opgenomen
               en trekt het omhoog in de constructie. Dit kan leiden tot schimmelvorming op muren en vloeren. Naast
               mogelijke gezondheidsklachten kan langdurige vochtbelasting ook leiden tot aantasting van bouwmaterialen,
-              wat de constructieve staat van het pand verzwakt. 
+              wat de constructieve staat van het pand verzwakt.
             </p>
             <p>
               Bij een hoge grondwaterstand kan bovendien water in de kruipruimte blijven staan, wat de luchtvochtigheid
@@ -313,7 +313,7 @@ const graphData = computed(() => {
             <div class="legenda space-y-3">
               <h3>Verdeling van funderingsrisico in de wijk</h3>
               <ol class="list--legenda">
-                <li v-for="item in graphData.legend" :style="item.color">{{ item.label }}</li>
+                <li v-for="item in graphData.legend" :key="item.label" :style="item.color">{{ item.label }}</li>
               </ol>
             </div>
           </div>

--- a/src/components/Print/Chapters/IncidentsChapter.vue
+++ b/src/components/Print/Chapters/IncidentsChapter.vue
@@ -59,7 +59,7 @@ const onLoad = async function onLoad({ map }: { map: Map }) {
   )
 
   // Add incident layer
-  // @ts-ignore
+  // @ts-expect-error JSON layer config has wider shape than mapbox LayerSpecification typing
   const layerSpecification: LayerSpecification = (await import('../../../config/layers/incident-district.json')).default
   map.addLayer(layerSpecification)
   map.setLayoutProperty('incident-district', 'visibility', 'visible')

--- a/src/components/Print/Chapters/InquirySampleChapter.vue
+++ b/src/components/Print/Chapters/InquirySampleChapter.vue
@@ -364,7 +364,7 @@ const foundationTypeGraph = computed(() => {
           <div class="legenda space-y-3">
             <h3>Type fundering (wijk)</h3>
             <ol class="list--legenda">
-              <li v-for="item in foundationTypeGraph.legend" :style="item.color">{{ item.label }}</li>
+              <li v-for="item in foundationTypeGraph.legend" :key="item.label" :style="item.color">{{ item.label }}</li>
             </ol>
           </div>
         </div>

--- a/src/datastructures/classes/EnumMethods.ts
+++ b/src/datastructures/classes/EnumMethods.ts
@@ -25,10 +25,10 @@ export class EnumMethods implements IEnumMethods {
       // using `in` to include prototype chain
       if (labelProperty in this) {
 
-        // @ts-ignore
+        // @ts-expect-error dynamic property access on `this` — labelProperty is computed
         console.log("Found property", this[labelProperty])
 
-        // @ts-ignore - We know that all enum labels are either a string or number.
+        // @ts-expect-error dynamic property access — all enum labels are either a string or number
         return this[labelProperty] as string|number
       }
     }

--- a/src/datastructures/classes/Location/Residence.ts
+++ b/src/datastructures/classes/Location/Residence.ts
@@ -12,7 +12,7 @@ export class Residence extends EnumMethods implements IResidence {
     super();
     
     this.id = data.id;
-    this.addressId = data.addressId,
+    this.addressId = data.addressId
     this.buildingId = data.buildingId
     this.latitude = data.latitude
     this.longitude = data.longitude

--- a/src/datastructures/fieldFormatters.ts
+++ b/src/datastructures/fieldFormatters.ts
@@ -1,7 +1,9 @@
 import { toEuro, toFormattedDate, toMM, toMMYear, toMeters, toNAP, toScale, toSquareM, toYear } from "./formatters";
 
 
-export const formattersByField = <Record<string, Function>>{
+type Formatter = (value: string | number) => string
+
+export const formattersByField: Record<string, Formatter> = {
   restorationCosts: toEuro,
   velocity: toMMYear,
   surfaceArea: toSquareM,

--- a/src/datastructures/formatters.ts
+++ b/src/datastructures/formatters.ts
@@ -37,17 +37,17 @@ export const toScale = function toScale(value: string | number): string {
 
 // example input format: 2022-05-11T15:09:24.289848Z
 // desired output dd-mm-jjjj
-export const toFormattedDate = function toFormattedDate(value: string): string {
+export const toFormattedDate = function toFormattedDate(value: string | number): string {
   try {
-    if (value === '') return value
+    if (value === '') return value as string
 
     return (new Date(value)).toLocaleDateString("nl-NL", {
       year: 'numeric',
       month: 'numeric',
       day: 'numeric',
     })
-  } catch (e) {
-    return value
+  } catch {
+    return String(value)
   }
 }
 

--- a/src/datastructures/interfaces/api/Location/IState.ts
+++ b/src/datastructures/interfaces/api/Location/IState.ts
@@ -1,3 +1,3 @@
 import { INamedGeoLocationWithWater } from "./INamedGeoLocationWithWater";
 
-export interface IState extends INamedGeoLocationWithWater {}
+export type IState = INamedGeoLocationWithWater

--- a/src/datastructures/interfaces/api/util.ts
+++ b/src/datastructures/interfaces/api/util.ts
@@ -1,6 +1,4 @@
-export interface IAPIModel {}
-
-export interface IEnumMethods extends IAPIModel {
+export interface IEnumMethods {
 
   className: string
 

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,6 +1,6 @@
 declare module '*.vue' {
   import { DefineComponent } from 'vue'
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type
   const component: DefineComponent<{}, {}, any>
   export default component
 }

--- a/src/store/building/analysis.ts
+++ b/src/store/building/analysis.ts
@@ -18,20 +18,20 @@ const isLoadingBuildingDataById: Ref<Record<string, boolean>> = ref({})
 /**
  * List of buildingIds that failed to load, along with info about the reason
  */
-const failedToLoadByBuildingId: Ref<Record<string, Record<string, any>>> = ref({})
+const failedToLoadByBuildingId: Ref<Record<string, Record<string, unknown>>> = ref({})
 
 /**
  * Whether the analysis data for a building have been retrieved previously
  */
 const buildingAnalysisDataHasBeenRetrieved = function buildingAnalysisDataHasBeenRetrieved(buildingId: string): boolean {
-  return analysisDataByBuildingId.value.hasOwnProperty(buildingId)
+  return Object.prototype.hasOwnProperty.call(analysisDataByBuildingId.value, buildingId)
 }
 
 /**
  * Whether the data failed to load (for whatever reason)
  */
 const buildingAnalysisDataFailedToLoad = function buildingAnalysisDataFailedToLoad(buildingId: string): boolean {
-  return failedToLoadByBuildingId.value.hasOwnProperty(buildingId)
+  return Object.prototype.hasOwnProperty.call(failedToLoadByBuildingId.value, buildingId)
 }
 
 /**

--- a/src/store/building/geolocations.ts
+++ b/src/store/building/geolocations.ts
@@ -19,20 +19,20 @@ const isLoadingBuildingDataById: Ref<Record<string, boolean>> = ref({})
 /**
  * List of buildingIds that failed to load, along with info about the reason
  */
-const failedToLoadByBuildingId: Ref<Record<string, Record<string, any>>> = ref({})
+const failedToLoadByBuildingId: Ref<Record<string, Record<string, unknown>>> = ref({})
 
 /**
  * Whether the location data for a building have been retrieved previously
  */
 const buildingLocationDataHasBeenRetrieved = function buildingLocationDataHasBeenRetrieved(buildingId: string): boolean {
-  return locationDataByBuildingId.value.hasOwnProperty(buildingId)
+  return Object.prototype.hasOwnProperty.call(locationDataByBuildingId.value, buildingId)
 }
 
 /**
  * Whether the location data failed to load (for whatever reason)
  */
 const buildingLocationDataFailedToLoad = function buildingLocationDataFailedToLoad(buildingId: string): boolean {
-  return failedToLoadByBuildingId.value.hasOwnProperty(buildingId)
+  return Object.prototype.hasOwnProperty.call(failedToLoadByBuildingId.value, buildingId)
 }
 
 /**

--- a/src/store/building/statistics.ts
+++ b/src/store/building/statistics.ts
@@ -29,21 +29,21 @@ const isLoadingBuildingDataById: Ref<Record<string, boolean>> = ref({})
 /**
  * List of buildingIds that failed to load, along with info about the reason
  */
-const failedToLoadByBuildingId: Ref<Record<string, Record<string, any>>> = ref({})
+const failedToLoadByBuildingId: Ref<Record<string, Record<string, unknown>>> = ref({})
 
 
 /**
  * Whether the statistics data for a building have been retrieved previously
  */
 const buildingStatisticsDataHasBeenRetrieved = function buildingStatisticsDataHasBeenRetrieved(buildingId: string): boolean {
-  return statisticsDataByBuildingId.value.hasOwnProperty(buildingId)
+  return Object.prototype.hasOwnProperty.call(statisticsDataByBuildingId.value, buildingId)
 }
 
 /**
  * Whether the data failed to load (for whatever reason)
  */
 const buildingStatisticsDataFailedToLoad = function buildingStatisticsDataFailedToLoad(buildingId: string): boolean {
-  return failedToLoadByBuildingId.value.hasOwnProperty(buildingId)
+  return Object.prototype.hasOwnProperty.call(failedToLoadByBuildingId.value, buildingId)
 }
 /**
  * Whether there is currently any statistics data available for a building

--- a/src/store/building/subsidence.ts
+++ b/src/store/building/subsidence.ts
@@ -18,21 +18,21 @@ const isLoadingBuildingDataById: Ref<Record<string, boolean>> = ref({})
 /**
  * List of buildingIds that failed to load, along with info about the reason
  */
-const failedToLoadByBuildingId: Ref<Record<string, Record<string, any>>> = ref({})
+const failedToLoadByBuildingId: Ref<Record<string, Record<string, unknown>>> = ref({})
 
 
 /**
  * Whether the subsidence data for a building have been retrieved previously
  */
 const buildingSubsidenceDataHasBeenRetrieved = function buildingSubsidenceDataHasBeenRetrieved(buildingId: string): boolean {
-  return subsidenceDataByBuildingId.value.hasOwnProperty(buildingId)
+  return Object.prototype.hasOwnProperty.call(subsidenceDataByBuildingId.value, buildingId)
 }
 
 /**
  * Whether the data failed to load (for whatever reason)
  */
 const buildingSubsidenceDataFailedToLoad = function buildingSubsidenceDataFailedToLoad(buildingId: string): boolean {
-  return failedToLoadByBuildingId.value.hasOwnProperty(buildingId)
+  return Object.prototype.hasOwnProperty.call(failedToLoadByBuildingId.value, buildingId)
 }
 /**
  * Whether there is currently any subsidence data available for a building

--- a/src/utils/fieldData.ts
+++ b/src/utils/fieldData.ts
@@ -54,7 +54,7 @@ export interface IFieldDataConfig {
   format?: boolean
 
   // Optional formatter function
-  formatter?: Function
+  formatter?: (value: string | number) => string
 
   // A default value if the property cannot be found on the data source
   default?: string
@@ -69,7 +69,7 @@ export class FieldDataConfig implements IFieldDataConfig {
   label?: string
   source?: MaybeRefOrGetter<IEnumMethods | null | undefined> // | ComputedRef<IEnumMethods|null|undefined>
   format?: boolean = true
-  formatter?: Function
+  formatter?: (value: string | number) => string
   group?: string
 
   default: string = 'Geen data'
@@ -186,7 +186,7 @@ export const retrieveAndFormatFieldData = function retrieveAndFormatFieldData(co
    * 
    * If the source is missing, or has no value for the property, we're done
    */
-  if (!source || !source?.hasOwnProperty(config.name)) {
+  if (!source || !Object.prototype.hasOwnProperty.call(source, config.name)) {
 
     // If there is a default label, use it
     if (config.default) {
@@ -201,7 +201,7 @@ export const retrieveAndFormatFieldData = function retrieveAndFormatFieldData(co
    * 
    * If the value is empty, we're done.
    * 
-   */ // @ts-ignore just keep quiet if you can't process something 
+   */ // @ts-expect-error just keep quiet if you can't process something 
   const sourcedFieldValue = source[config.name]
   if (sourcedFieldValue || sourcedFieldValue === false || sourcedFieldValue === 0) {
     dataObj.fieldValue = sourcedFieldValue
@@ -245,9 +245,9 @@ export const retrieveAndFormatFieldData = function retrieveAndFormatFieldData(co
   } else {
     // Apply formatting if there is a field formatter
     if (config.formatter) {
-      dataObj.formattedFieldValueLabel = config.formatter(dataObj.fieldValueLabel)
+      dataObj.formattedFieldValueLabel = config.formatter(dataObj.fieldValueLabel as string | number)
     } else if (formattersByField[config.name]) {
-      dataObj.formattedFieldValueLabel = formattersByField[config.name](dataObj.fieldValueLabel)
+      dataObj.formattedFieldValueLabel = formattersByField[config.name](dataObj.fieldValueLabel as string | number)
     } else {
 
       if (dataObj.fieldValueLabel === true || dataObj.fieldValueLabel === false) {


### PR DESCRIPTION
## Summary
Clears the 48 lint errors that were surfaced by Phase 1a's flat ESLint config. After this lands, \`pnpm lint\` exits 0 — future regressions are visible.

### Mechanical fixes
- \`@ts-ignore\` → \`@ts-expect-error\` across the codebase (sed pass), with descriptions added where the rule requires (>=3 chars).
- \`obj.hasOwnProperty(x)\` → \`Object.prototype.hasOwnProperty.call(obj, x)\` in stores and fieldData.
- \`catch (e)\` → \`catch\` when \`e\` is unused.
- Empty \`interface X extends Y {}\` → \`type X = Y\`.
- Empty \`interface IAPIModel {}\` dropped (no-op marker, only used as IEnumMethods's parent).
- shims-vue.d.ts: update the eslint-disable comment to match the new rule name (\`no-empty-object-type\`, not \`ban-types\`).

### Real bugs fixed
- **BarChart.vue:** \`vue/no-dupe-keys\` collision between the \`gradient\` prop and the \`chartjs-plugin-gradient\` import — renamed the import to \`gradientPlugin\`.
- **MapBox.vue:** \`vue/no-mutating-props\` — \`Object.assign(options, …)\` was mutating the prop; switched to \`Object.assign({}, options, …)\`.
- **FoundationRiskChapter.vue + InquirySampleChapter.vue:** \`vue/require-v-for-key\` — added \`:key\` on legend list items.
- **FoundationRiskChapter.vue:** stripped a \`U+202F NARROW NO-BREAK SPACE\` that snuck into a Dutch sentence.
- **StatisticsModal.vue:** removed stale \`const emit = defineEmits(...)\` that never invoked \`emit\`; wrapped a switch case body in \`{}\` so the inner \`const\` declaration is scoped (\`no-case-declarations\`).

### Type tightening
- \`failedToLoadByBuildingId\`: \`any\` → \`unknown\` in 4 stores.
- \`formattersByField\`: \`<Record<string, Function>>\` → \`Record<string, (value: string|number) => string>\` with a \`Formatter\` type alias; \`toFormattedDate\` widened to \`string|number\` to match.
- \`fieldData.ts\`: \`formatter?: Function\` → \`formatter?: (value: string|number) => string\` (with cast at call site since the call may pass a wider union depending on how the upstream filter shapes things).

### Pragmatic concessions
- Chart.js's generic configuration types are too strict to assign \`new Chart(...)\` to a typed \`Chart | null\` without a cascade of generic-parameter wrangling; kept \`let chart: any | null\` with an explicit eslint-disable in BarChart/PieChart/ScatterChart.
- Tooltip callback context in ScatterChart kept as \`(context: any)\` with eslint-disable — typing it properly would mean importing \`TooltipItem<'scatter'>\` and that's beyond this lint cleanup's scope.

## Test plan
- [x] \`pnpm exec vue-tsc\` — clean (PIPESTATUS-checked)
- [x] \`pnpm exec eslint src/\` — clean
- [x] \`pnpm run build\` — clean
- [ ] After merge of this + #25 (Tailwind 4): regression-test the report SPA against a known-good building

🤖 Generated with [Claude Code](https://claude.com/claude-code)