### PR TITLE
fix(reactivity): use `key in proxy` instead of Object.prototype.hasOwnProperty.call

### DIFF
--- a/src/store/building/analysis.ts
+++ b/src/store/building/analysis.ts
@@ -24,14 +24,14 @@ const failedToLoadByBuildingId: Ref<Record<string, Record<string, unknown>>> = r
  * Whether the analysis data for a building have been retrieved previously
  */
 const buildingAnalysisDataHasBeenRetrieved = function buildingAnalysisDataHasBeenRetrieved(buildingId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(analysisDataByBuildingId.value, buildingId)
+  return buildingId in analysisDataByBuildingId.value
 }
 
 /**
  * Whether the data failed to load (for whatever reason)
  */
 const buildingAnalysisDataFailedToLoad = function buildingAnalysisDataFailedToLoad(buildingId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(failedToLoadByBuildingId.value, buildingId)
+  return buildingId in failedToLoadByBuildingId.value
 }
 
 /**

--- a/src/store/building/geolocations.ts
+++ b/src/store/building/geolocations.ts
@@ -25,14 +25,14 @@ const failedToLoadByBuildingId: Ref<Record<string, Record<string, unknown>>> = r
  * Whether the location data for a building have been retrieved previously
  */
 const buildingLocationDataHasBeenRetrieved = function buildingLocationDataHasBeenRetrieved(buildingId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(locationDataByBuildingId.value, buildingId)
+  return buildingId in locationDataByBuildingId.value
 }
 
 /**
  * Whether the location data failed to load (for whatever reason)
  */
 const buildingLocationDataFailedToLoad = function buildingLocationDataFailedToLoad(buildingId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(failedToLoadByBuildingId.value, buildingId)
+  return buildingId in failedToLoadByBuildingId.value
 }
 
 /**

--- a/src/store/building/statistics.ts
+++ b/src/store/building/statistics.ts
@@ -36,14 +36,14 @@ const failedToLoadByBuildingId: Ref<Record<string, Record<string, unknown>>> = r
  * Whether the statistics data for a building have been retrieved previously
  */
 const buildingStatisticsDataHasBeenRetrieved = function buildingStatisticsDataHasBeenRetrieved(buildingId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(statisticsDataByBuildingId.value, buildingId)
+  return buildingId in statisticsDataByBuildingId.value
 }
 
 /**
  * Whether the data failed to load (for whatever reason)
  */
 const buildingStatisticsDataFailedToLoad = function buildingStatisticsDataFailedToLoad(buildingId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(failedToLoadByBuildingId.value, buildingId)
+  return buildingId in failedToLoadByBuildingId.value
 }
 /**
  * Whether there is currently any statistics data available for a building

--- a/src/store/building/subsidence.ts
+++ b/src/store/building/subsidence.ts
@@ -25,14 +25,14 @@ const failedToLoadByBuildingId: Ref<Record<string, Record<string, unknown>>> = r
  * Whether the subsidence data for a building have been retrieved previously
  */
 const buildingSubsidenceDataHasBeenRetrieved = function buildingSubsidenceDataHasBeenRetrieved(buildingId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(subsidenceDataByBuildingId.value, buildingId)
+  return buildingId in subsidenceDataByBuildingId.value
 }
 
 /**
  * Whether the data failed to load (for whatever reason)
  */
 const buildingSubsidenceDataFailedToLoad = function buildingSubsidenceDataFailedToLoad(buildingId: string): boolean {
-  return Object.prototype.hasOwnProperty.call(failedToLoadByBuildingId.value, buildingId)
+  return buildingId in failedToLoadByBuildingId.value
 }
 /**
  * Whether there is currently any subsidence data available for a building

--- a/src/utils/fieldData.ts
+++ b/src/utils/fieldData.ts
@@ -186,7 +186,7 @@ export const retrieveAndFormatFieldData = function retrieveAndFormatFieldData(co
    * 
    * If the source is missing, or has no value for the property, we're done
    */
-  if (!source || !Object.prototype.hasOwnProperty.call(source, config.name)) {
+  if (!source || !(config.name in source)) {
 
     // If there is a default label, use it
     if (config.default) {


### PR DESCRIPTION
## Summary
Hotfix for the empty-card regression after #25/#26/#27. Page renders, CSS works, all 5 API calls succeed and all setters fire — but the chapter content never appears because \`hasAllBuildingInformation\` (the gate in \`PDF.vue\`) never flips to \`true\`.

## Root cause
Vue 3's reactive proxy has a special-case \`get\` trap for \`hasOwnProperty\` that returns a wrapped function which calls \`track(target, HAS, key)\` before delegating. So \`proxy.hasOwnProperty(key)\` IS reactivity-tracked.

\`Object.prototype.hasOwnProperty.call(proxy, key)\` **bypasses** that wrapper — it invokes the unwrapped native function with the proxy as \`this\`. The internal \`[[GetOwnProperty]]\` uses the \`getOwnPropertyDescriptor\` trap, which Vue's reactive handler doesn't override (default Reflect behavior, no tracking). So the dependency on the buildingId key is never registered, the SET on that key never triggers re-evaluation of the computed downstream, and the gate stays false forever.

The eslint \`no-prototype-builtins\` rule was what led me to the wrong rewrite in Phase 1c (#26). I optimized for \"don't access Object.prototype methods directly\" without realizing Vue 3 has runtime semantics tied to the prototype-chain access path.

## Fix
Use \`key in proxy\` instead. Equivalent semantics for our use case (plain \`Record<string, T>\` objects with no surprising prototype chain). The \`in\` operator uses the proxy's \`has\` trap, which Vue 3 **does** override with tracking:

\`\`\`ts
has(target, key) {
  const result = Reflect.has(target, key)
  if (!isSymbol(key) || !builtInSymbols.has(key)) {
    track(target, TrackOpTypes.HAS, key)
  }
  return result
}
\`\`\`

So \`buildingId in store.value\` registers the dep on \`buildingId\`, and the SET on that key triggers re-evaluation. Gate flips when expected.

Same fix for the analogous call in \`src/utils/fieldData.ts\` since \`source\` is also a reactive value (\`toValue()\` of a ref).

## Verified
- \`pnpm exec vue-tsc\` clean (PIPESTATUS-checked)
- \`pnpm exec eslint src/\` clean
- \`pnpm run build\` clean
- 9 lines changed across 5 files

## Test plan
- [x] All build/lint/type-check clean
- [ ] After deploy: known-good building report should render full chapter content (not just the empty card frame)

🤖 Generated with [Claude Code](https://claude.com/claude-code)