### PR TITLE
fix(report): three paid-PDF correctness bugs

### DIFF
--- a/src/datastructures/formatters.ts
+++ b/src/datastructures/formatters.ts
@@ -12,11 +12,11 @@ export const toMeters = function toMeters(value: string | number): string {
 }
 
 export const toSquareM = function toSquareM(value: string | number): string {
-  return `${parseFloat(value + '').toFixed(2)} m2`
+  return `${parseFloat(value + '').toFixed(2)} m²`
 }
 
 export const toCubicM = function toCubicM(value: string | number): string {
-  return `${parseFloat(value + '').toFixed(2)} m3`
+  return `${parseFloat(value + '').toFixed(2)} m³`
 }
 
 export const toNAP = function toNAP(value: string | number): string {

--- a/src/store/building/inquiries.ts
+++ b/src/store/building/inquiries.ts
@@ -100,11 +100,22 @@ const getCombinedInquiryDataByBuildingId = function getCombinedInquiryDataByBuil
   // Match reports & samples for every entry
   const combinedData: ICombinedInquiryData[] = []
 
-  // Go over all inquires related to the building
+  // Sort by documentDate desc, with report.id desc as a tiebreaker, so
+  // consumers using `[0]` get a deterministic "most recent" sample
+  // across runs — a non-deterministic order produces a different paid
+  // PDF every render for buildings with multiple inquiries.
   getInquiryByBuildingId(buildingId)
+    .slice()
+    .sort((a, b) => {
+      const byDate = (b.documentDate || '').localeCompare(a.documentDate || '')
+      return byDate !== 0 ? byDate : b.id - a.id
+    })
     .forEach((report: IInquiryReport) => {
-      // Get all samples related to the inquiry & building combination
-      const samples = getInquirySamplesByInquiryId(report.id)
+      // Get all samples related to the inquiry & building combination.
+      // getInquirySamplesByInquiryId returns undefined for inquiries with
+      // no samples (the key is only populated when samples exist), so
+      // default to [] before filtering.
+      const samples = (getInquirySamplesByInquiryId(report.id) || [])
         .filter(sample => {
           return sampleIdsForBuilding.includes(sample.id)
         })

--- a/src/views/PDF.vue
+++ b/src/views/PDF.vue
@@ -219,10 +219,10 @@ onUnmounted(() => {
         </p>
         <ul>
           <li>
-            <strong>Vastgesteld:</strong> Wanneer er geen directe onderzoeksgegevens beschikbaar zijn voor het pand zelf, maar wel voor naastgelegen panden binnen dezelfde bouw- of funderingseenheid, wordt het funderingstype en de risicobeoordeling beschouwd als afgeleid. Deze afleiding is doorgaans goed onderbouwd, omdat vergelijkbare constructies en omstandigheden gelden
+            <strong>Vastgesteld:</strong> Daar waar specifieke onderzoeksgegevens van het betreffende pand beschikbaar zijn, is de betrouwbaarheid van de uitgangspunten hoog. Het funderingstype en/of het funderingsrisico wordt dan als vastgesteld beschouwd.
           </li>
           <li>
-            <strong>Afgeleid:</strong> Daar waar specifieke onderzoeksgegevens van het betreffende pand beschikbaar zijn, is de betrouwbaarheid van de uitgangspunten hoog. Het funderingstype en/of het funderingsrisico wordt dan als vastgesteld beschouwd.
+            <strong>Afgeleid:</strong> Wanneer er geen directe onderzoeksgegevens beschikbaar zijn voor het pand zelf, maar wel voor naastgelegen panden binnen dezelfde bouw- of funderingseenheid, wordt het funderingstype en de risicobeoordeling beschouwd als afgeleid. Deze afleiding is doorgaans goed onderbouwd, omdat vergelijkbare constructies en omstandigheden gelden.
           </li>
           <li>
             <strong>Modelmatig (indicatief):</strong> Als er geen gegevens beschikbaar zijn van het pand zelf of van omliggende panden, wordt gebruikgemaakt van een modelanalyse. De uitkomsten daarvan zijn indicatief en hebben een lagere betrouwbaarheid.


### PR DESCRIPTION
## Summary

Three bugs that all show up directly in the customer-visible PDF deliverable (`report.fundermaps.com` renders the same Vue components PDF.co captures, so a regression here hits the paid artifact, not just dev).

### 1. Disclaimer label/body mismatch (`src/views/PDF.vue:198-203`)
The body under **Vastgesteld** described a neighbour-derived scenario; the body under **Afgeleid** described direct research-data. Swapping the `<li>` blocks fixes both the term-to-definition match *and* gives the natural reliability ordering Vastgesteld → Afgeleid → Modelmatig.

### 2. `m2` / `m3` → `m²` / `m³` (`src/datastructures/formatters.ts:15,19`)
ASCII fallback in a paid Dutch report. Replaced with the proper Unicode superscript characters.

### 3. Non-deterministic inquiry sample selection (`src/store/building/inquiries.ts:106-110`)
`BuildingChapter`, `LocationChapter`, and `InquirySampleChapter` all read `inqueryData[0]?.sample` with no ORDER BY guarantee — a multi-inquiry building produced a different PDF every run. Now sorted by `report.documentDate` descending in the store function so `[0]` is always the most-recent inquiry.

> **Out of scope (intentional):** the "showing 1 of N" UX hint that would tell the customer when other samples exist. That's a layout/UX call — want to see this PR rendered to PDF first before deciding placement, especially in `BuildingChapter` where the only sample-derived field is "Onderbouw".

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` succeeds
- [x] `eslint src/` clean
- [x] Built bundle now contains `Vastgesteld:</strong> Daar waar specifieke onderzoeksgegevens` (verified the swap landed) and `m²` / `m³` (verified Unicode landed)
- [ ] Render a sample PDF off this branch and diff against current main to confirm the disclaimer block reads correctly and unit values render with proper superscripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)