### PR TITLE
chore(report): drop debug console.log from print render path; fix inquery typo

### DIFF
--- a/src/components/Print/Chapters/BuildingChapter.vue
+++ b/src/components/Print/Chapters/BuildingChapter.vue
@@ -34,7 +34,7 @@ const locationData = computed(() => {
 /**
  * Data inquiry sample source for panel
  */
-const inqueryData: ComputedRef<ICombinedInquiryData[]> = computed(() => {
+const inquiryData: ComputedRef<ICombinedInquiryData[]> = computed(() => {
   if (!buildingId.value) return []
   return getCombinedInquiryDataByBuildingId(buildingId.value) || []
 })
@@ -55,7 +55,7 @@ const fieldsWithData = computed(() => {
       new FieldDataConfig({
         label: 'Onderbouw',
         name: 'substructure',
-        source: inqueryData.value?.[0]?.sample,
+        source: inquiryData.value?.[0]?.sample,
       }),
       new FieldDataConfig({
         label: 'BAG ID',

--- a/src/components/Print/Chapters/DisplacementDataChapter.vue
+++ b/src/components/Print/Chapters/DisplacementDataChapter.vue
@@ -53,7 +53,6 @@ const subsidenceData = computed(() => {
 })
 
 const graphData = computed(() => {
-  console.log("subsidenceData", subsidenceData.value)
   return {
     labels: [],
     data: subsidenceData.value?.map(item => {

--- a/src/components/Print/Chapters/InquirySampleChapter.vue
+++ b/src/components/Print/Chapters/InquirySampleChapter.vue
@@ -82,7 +82,7 @@ const foundationIconName = computed(() => {
 /**
  * Data inquiry sample source for panel
  */
-const inqueryData: ComputedRef<ICombinedInquiryData[]> = computed(() => {
+const inquiryData: ComputedRef<ICombinedInquiryData[]> = computed(() => {
   if (!buildingId.value) return []
   return getCombinedInquiryDataByBuildingId(buildingId.value) || []
 })
@@ -94,7 +94,7 @@ const inqueryData: ComputedRef<ICombinedInquiryData[]> = computed(() => {
  */
 const fieldsWithFoundationData = computed(() => {
   const fieldsConfig = applyContextToFieldDataConfigs({
-    source: inqueryData.value?.[0]?.sample || undefined,
+    source: inquiryData.value?.[0]?.sample || undefined,
     labels: inquirySampleFieldLabels,
     configs: [
       new FieldDataConfig({ name: 'foundationTypeReliability', source: analysisData }),
@@ -126,7 +126,7 @@ const groupHasData: Record<string, boolean> = {
 const sampleFieldsWithData: ComputedRef<Record<string, CompletedFieldData[]>> = computed(() => {
 
   const sampleFieldsConfig = applyContextToFieldDataConfigs({
-    source: inqueryData.value?.[0]?.sample || undefined,
+    source: inquiryData.value?.[0]?.sample || undefined,
     labels: inquirySampleFieldLabels,
     configs: [
 

--- a/src/components/Print/Chapters/LocationChapter.vue
+++ b/src/components/Print/Chapters/LocationChapter.vue
@@ -62,7 +62,7 @@ const analysisData = computed(() => {
 /**
  * Data inquiry sample source for panel
  */
-const inqueryData: ComputedRef<ICombinedInquiryData[]> = computed(() => {
+const inquiryData: ComputedRef<ICombinedInquiryData[]> = computed(() => {
   if (!buildingId.value) return []
   return getCombinedInquiryDataByBuildingId(buildingId.value) || []
 })
@@ -88,7 +88,7 @@ const fieldsWithAnalysisData = computed(() => {
 
 const fieldsWithInquirySampleData = computed(() => {
   const fieldsConfig = applyContextToFieldDataConfigs({
-    source: inqueryData.value?.[0]?.sample || undefined,
+    source: inquiryData.value?.[0]?.sample || undefined,
     labels: inquirySampleFieldLabels,
     configs: [
       new FieldDataConfig({ name: 'cpt' }), // sondering

--- a/src/components/Print/Chapters/ReportingChapter.vue
+++ b/src/components/Print/Chapters/ReportingChapter.vue
@@ -19,7 +19,7 @@ const { getStatisticsDataByBuildingId } = useStatisticsStore()
 /**
  * Data inquiry sample source for panel
  */
-const inqueryData: ComputedRef<IInquiryReport[]> = computed(() => {
+const inquiryData: ComputedRef<IInquiryReport[]> = computed(() => {
   if (!buildingId.value) return []
   return getInquiryByBuildingId(buildingId.value) || []
 })
@@ -51,14 +51,14 @@ const reportGraph = computed(() => {
 </script>
 
 <template>
-  <Chapter v-if="inqueryData.length || reportGraph.data.length" icon="file-report" title="Rapportage">
+  <Chapter v-if="inquiryData.length || reportGraph.data.length" icon="file-report" title="Rapportage">
 
     <section class="break-before-avoid-page break-inside-avoid space-y-7">
-      <p v-if="inqueryData.length !== 0">
+      <p v-if="inquiryData.length !== 0">
         De volgende rapportage(s) zijn beschikbaar voor dit pand en zijn gebruikt voor het opstellen van het
         funderingsrisicorapport
       </p>
-      <table v-if="inqueryData.length !== 0" class="w-full">
+      <table v-if="inquiryData.length !== 0" class="w-full">
         <thead>
           <tr>
             <th>Nummer</th>
@@ -68,7 +68,7 @@ const reportGraph = computed(() => {
           </tr>
         </thead>
         <tbody>
-          <tr v-for="report in inqueryData" :key="report.id">
+          <tr v-for="report in inquiryData" :key="report.id">
             <td>{{ report.id }}</td>
             <td>{{ report.documentName }}</td>
             <td>{{ report.typeLabel }}</td>
@@ -82,5 +82,5 @@ const reportGraph = computed(() => {
     </section>
 
   </Chapter>
-  <PageBreak v-if="inqueryData.length || reportGraph.data.length" />
+  <PageBreak v-if="inquiryData.length || reportGraph.data.length" />
 </template>

--- a/src/datastructures/classes/EnumMethods.ts
+++ b/src/datastructures/classes/EnumMethods.ts
@@ -16,18 +16,10 @@ export class EnumMethods implements IEnumMethods {
   getEnumLabel(property: string): string|number|null {
     // Check if the property is an enum
     if (this.isEnum(property)) {
-      console.log('Check - it is an enum')
-
       const labelProperty = `${property}Label`
-
-      console.log("Property", labelProperty)
 
       // using `in` to include prototype chain
       if (labelProperty in this) {
-
-        // @ts-expect-error dynamic property access on `this` — labelProperty is computed
-        console.log("Found property", this[labelProperty])
-
         // @ts-expect-error dynamic property access — all enum labels are either a string or number
         return this[labelProperty] as string|number
       }

--- a/src/store/building/analysis.ts
+++ b/src/store/building/analysis.ts
@@ -74,7 +74,7 @@ const loadAnalysisDataByBuildingId = async function loadAnalysisDataByBuildingId
     analysisDataByBuildingId.value[buildingId] = response || null
 
   } catch (e) {
-    console.log("Error loading analysis data by building id", e)
+    console.error("Error loading analysis data by building id", e)
 
     // TODO: Catch-em all... and maybe do something with them?
     // TODO: Create structure for failures

--- a/src/store/building/geolocations.ts
+++ b/src/store/building/geolocations.ts
@@ -102,7 +102,7 @@ const loadLocationDataByBuildingId = async (buildingId: string, cache: boolean =
       : null
 
   } catch (e) {
-    console.log("Error loading location data by building id", e)
+    console.error("Error loading location data by building id", e)
 
     // TODO: Catch-em all... and maybe do something more with them?
     // TODO: Create structure for failures

--- a/src/store/building/incidents.ts
+++ b/src/store/building/incidents.ts
@@ -85,7 +85,7 @@ const loadIncidentReportDataByBuildingId = async function loadIncidentReportData
     setIncidentDataByBuildingId(buildingId, response)
 
   } catch (e) {
-    console.log("Error loading incidentReport data by building id", e)
+    console.error("Error loading incidentReport data by building id", e)
 
     // TODO: Catch-em all... and maybe do something with them?
   }

--- a/src/store/building/inquiries.ts
+++ b/src/store/building/inquiries.ts
@@ -100,21 +100,14 @@ const getCombinedInquiryDataByBuildingId = function getCombinedInquiryDataByBuil
   // Match reports & samples for every entry
   const combinedData: ICombinedInquiryData[] = []
 
-  console.log("Get Combined inquiry data", getInquiryByBuildingId(buildingId))
-
   // Go over all inquires related to the building
   getInquiryByBuildingId(buildingId)
     .forEach((report: IInquiryReport) => {
-
-      console.log("report", report.id)
-
       // Get all samples related to the inquiry & building combination
       const samples = getInquirySamplesByInquiryId(report.id)
         .filter(sample => {
           return sampleIdsForBuilding.includes(sample.id)
         })
-
-      console.log("samples", samples)
 
       // If there are none, add the report without sample
       if (samples.length === 0) {
@@ -134,8 +127,6 @@ const getCombinedInquiryDataByBuildingId = function getCombinedInquiryDataByBuil
       }
     })
 
-  console.log(combinedData)
-
   return combinedData
 }
 
@@ -143,15 +134,12 @@ const getCombinedInquiryDataByBuildingId = function getCombinedInquiryDataByBuil
  * Set the retrieved report data
  */
 const setInquiryDataByBuildingId = function setInquiryDataByBuildingId(buildingId: string, reports: IInquiryReport[], samples: IInquirySample[]) {
-
-  console.log('setInquiryDataByBuildingId', buildingId, reports, samples)
-
   reports.forEach((inquiry: IInquiryReport) => {
     inquiriesById.value[inquiry.id] = new Inquiry(inquiry)
   })
 
   // Connect the inquiryIds to the buildingId
-  inquiryIdsByBuildingId.value[buildingId] = reports.map((inquery: IInquiryReport) => inquery.id)
+  inquiryIdsByBuildingId.value[buildingId] = reports.map((inquiry: IInquiryReport) => inquiry.id)
 
   samples.forEach((sample: IInquirySample) => {
     sample = new InquirySample(sample)
@@ -201,7 +189,7 @@ const loadInquiryDataByBuildingId = async function loadInquiryDataByBuildingId(b
 
     setInquiryDataByBuildingId(buildingId, reports, samples)
   } catch (e) {
-    console.log("Error loading inquiry data by building id", e)
+    console.error("Error loading inquiry data by building id", e)
 
     // TODO: Catch-em all... and maybe do something with them?
   }

--- a/src/store/building/recovery.ts
+++ b/src/store/building/recovery.ts
@@ -101,21 +101,14 @@ const getCombinedRecoveryDataByBuildingId = function getCombinedRecoveryDataByBu
   // Match reports & samples for every entry
   const combinedData: ICombinedRecoveryData[] = []
 
-  console.log("Get Combined recovery data")
-
   // Go over all inquires related to the building
   getRecoveryReportByBuildingId(buildingId)
     .forEach((report: IRecoveryReport) => {
-
-      console.log("report", report.id)
-
       // Get all samples related to the recovery & building combination
       const samples = getRecoverySamplesByRecoveryReportId(report.id)
         .filter(sample => {
           return sampleIdsForBuilding.includes(sample.id)
         })
-
-      console.log("samples", samples)
 
       // If there are none, add the report without sample
       if (samples.length === 0) {
@@ -135,8 +128,6 @@ const getCombinedRecoveryDataByBuildingId = function getCombinedRecoveryDataByBu
       }
     })
 
-  console.log(combinedData)
-
   return combinedData
 }
 
@@ -145,15 +136,12 @@ const getCombinedRecoveryDataByBuildingId = function getCombinedRecoveryDataByBu
  * Set the retrieved report data
  */
 const setRecoveryDataByBuildingId = function setRecoveryDataByBuildingId(buildingId: string, reports: IRecoveryReport[], samples: IRecoverySample[]) {
-
-  console.log(buildingId, reports, samples)
-
   reports.forEach((report: IRecoveryReport) => {
     recoveryReportsById.value[report.id] = new RecoveryReport(report)
   })
 
   // Connect the recoveryIds to the buildingId
-  recoveryReportIdsByBuildingId.value[buildingId] = reports.map((inquery: IRecoveryReport) => inquery.id)
+  recoveryReportIdsByBuildingId.value[buildingId] = reports.map((report: IRecoveryReport) => report.id)
 
   samples.forEach((sample: IRecoverySample) => {
     sample = new RecoverySample(sample)
@@ -213,7 +201,7 @@ const loadRecoveryReportDataByBuildingId = async function loadRecoveryReportData
     }
 
   } catch (e) {
-    console.log("Error loading recoveryReport data by building id", e)
+    console.error("Error loading recoveryReport data by building id", e)
 
     // TODO: Catch-em all... and maybe do something with them?
   }

--- a/src/store/building/statistics.ts
+++ b/src/store/building/statistics.ts
@@ -85,7 +85,7 @@ const loadStatisticsDataByBuildingId = async function loadStatisticsDataByBuildi
     statisticsDataByBuildingId.value[buildingId] = response || null
 
   } catch (e) {
-    console.log("Error loading statistics data by building id", e)
+    console.error("Error loading statistics data by building id", e)
 
     // TODO: Catch-em all... and maybe do something with them?
     // TODO: Create structure for failures

--- a/src/store/building/subsidence.ts
+++ b/src/store/building/subsidence.ts
@@ -74,7 +74,7 @@ const loadSubsidenceDataByBuildingId = async function loadSubsidenceDataByBuildi
     subsidenceDataByBuildingId.value[buildingId] = response || null
 
   } catch (e) {
-    console.log("Error loading subsidence data by building id", e)
+    console.error("Error loading subsidence data by building id", e)
 
     // TODO: Catch-em all... and maybe do something with them?
     // TODO: Create structure for failures

--- a/src/utils/fieldData.ts
+++ b/src/utils/fieldData.ts
@@ -15,10 +15,6 @@ export const applyContextToFieldDataConfigs = function (
     labels?: Record<string, string>
   }
 ) {
-
-  console.log('Apply context')
-  console.log(data.source)
-
   return (data.configs || []).map(
     (config: IFieldDataConfig) => {
       // If no specific source was set on the config, apply the source from the context
@@ -150,8 +146,6 @@ export const retrieveAndFormatFieldData = function retrieveAndFormatFieldData(co
 
   const dataObj = new CompletedFieldData(config.name, config.group)
 
-  console.log("format field", dataObj, config)
-
   /**
    * A data source is required, unless intentionally set to `null`, or if we _do_ have a label in the config
    */
@@ -220,9 +214,7 @@ export const retrieveAndFormatFieldData = function retrieveAndFormatFieldData(co
    * If the field is an enum, we translate the raw field value into an enum label
    */
   if (source?.isEnum(config.name)) {
-    console.log(`${config.name} is an enum`)
     dataObj.fieldValueLabel = source?.getEnumLabel(config.name)
-    console.log(`${config.name} enum value`, dataObj.fieldValueLabel)
   } else {
     // Otherwise use the value we found as field value label
     dataObj.fieldValueLabel = dataObj.fieldValue
@@ -257,9 +249,6 @@ export const retrieveAndFormatFieldData = function retrieveAndFormatFieldData(co
       }
     }
   }
-
-  // Report the end result
-  console.log(config.name, dataObj)
 
   return dataObj
 }


### PR DESCRIPTION
## Summary

Same Vue components render both `report.fundermaps.com` and the paid PDF (PDF.co captures the rendered HTML), so anything chatty here ends up in PDF.co sidecar logs and reads as unfinished code in a deliverable artifact.

### console.* cleanup (29 → 9)
- Removed **20 pure-debug `console.log` calls**. The worst offenders were in the per-field hot path: `src/utils/fieldData.ts` had 6 logs that fired *once per field per chapter*.
- Upgraded **7 catch-block `console.log(\"Error ...\", e)` → `console.error(...)`** across the building stores (analysis/geolocations/incidents/inquiries/recovery/statistics/subsidence) so genuine errors still surface.
- Kept the **2 existing `console.error`** calls in `fieldData.ts` that warn on misconfigured `FieldDataConfig` — legitimate dev-feedback.

### Typo cleanup: `inqueryData` → `inquiryData`
- 4 chapters (`Building`, `Location`, `InquirySample`, `Reporting`) all had a consistently misspelled local computed `inqueryData`.
- 2 stores had stray `inquery` lambda parameters; `recovery.ts:156` was double-wrong (typo AND wrong noun — it's a recovery report, not an inquiry) and is now `(report: IRecoveryReport)`.

### Out of scope (intentional)
The 6 TODOs in `PDF.vue` (cache, retry logic, error handling) and chapters (`BuildingChapter:54` Gebruik & Bestemming, `FoundationRiskChapter:66` refactor) are real architectural concerns. Better tracked as issues than silently deleted — leaving them alone in this PR.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean — bundle 2174.58 KB → 2173.89 KB (small shrink from removed log strings)
- [x] `eslint src/` clean
- [x] Verified zero `console.log` and zero `inquery` left in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)