### PR TITLE
fix(report): reliable PDF readiness signal, mapbox 'idle', chart animation:false in initial options

### DIFF
--- a/src/components/Charts/BarChart.vue
+++ b/src/components/Charts/BarChart.vue
@@ -99,6 +99,11 @@ const createChart = function createChart(
         ]
       },
       options: {
+        // animation:false in initial options so the very first paint is
+        // static — required for a deterministic PDF.co snapshot. Setting
+        // chart.options.animation after construction is too late: Chart.js
+        // has already started animating by then.
+        animation: false,
         indexAxis: horizontal ? 'y' : 'x',
         scales: {
           y: {
@@ -126,9 +131,6 @@ const createChart = function createChart(
       },
     }
   );
-
-  // Disable animation in the popup, it is too much
-  chart.options.animation = false; 
 }
 
 onMounted(() => {

--- a/src/components/Charts/ScatterChart.vue
+++ b/src/components/Charts/ScatterChart.vue
@@ -67,6 +67,11 @@ const createChart = function createChart(
         ]
       },
       options: {
+        // animation:false in initial options so the very first paint is
+        // static — required for a deterministic PDF.co snapshot. Setting
+        // chart.options.animation after construction is too late: Chart.js
+        // has already started animating by then.
+        animation: false,
         indexAxis: horizontal ? 'y' : 'x',
         scales: {
           y: {
@@ -115,9 +120,6 @@ const createChart = function createChart(
       },
     }
   );
-
-  // Disable animation in the popup, it is too much
-  chart.options.animation = false; 
 }
 
 onMounted(() => {

--- a/src/components/Common/Mapbox/MapBox.vue
+++ b/src/components/Common/Mapbox/MapBox.vue
@@ -66,7 +66,11 @@ const loadMapbox = function() {
 
   // provide('map', map)
 
-  map.on('load', () => {
+  // Wait for the first 'idle' event (everything painted, no in-flight tile
+  // requests, no animations) rather than 'load' (style + initial tile batch
+  // ready, but vector features may still be painting). 'idle' is strictly
+  // stronger and is what we want for a deterministic PDF.co snapshot.
+  map.once('idle', () => {
     loaded.value = true
     emit('load', { map, sdk: mapboxSDK } )
   })

--- a/src/views/PDF.vue
+++ b/src/views/PDF.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeMount, watch, computed } from 'vue';
+import { onBeforeMount, onUnmounted, watch, computed, nextTick } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import api from '@/services/api';
@@ -146,6 +146,29 @@ onBeforeMount(() => {
   }
 
   setBuildingId(route.params.buildingId as string)
+})
+
+// Expose a deterministic ready-signal for PDF.co (and any other headless
+// renderer): wait until all building data has loaded *and* the chapters
+// have flushed to the DOM, then set [data-pdf-ready="true"] on <html>.
+// Configure the renderer to wait for that selector instead of the
+// network-idle heuristic, which can fire before this template's v-if
+// has actually mounted the chapter tree.
+watch(
+  () => hasAllBuildingInformation.value,
+  async (ready) => {
+    if (!ready) {
+      document.documentElement.removeAttribute('data-pdf-ready')
+      return
+    }
+    await nextTick()
+    document.documentElement.setAttribute('data-pdf-ready', 'true')
+  },
+  { immediate: true }
+)
+
+onUnmounted(() => {
+  document.documentElement.removeAttribute('data-pdf-ready')
 })
 
 </script>


### PR DESCRIPTION
## Summary

Three race conditions where PDF.co could snapshot before the rendered HTML matches the intended deliverable. None of them is necessarily firing today (we don't have visible bug reports), but they're all silent corruption modes — when they fire, the PDF is wrong and there's no log.

### 1. PDF readiness signal (`src/views/PDF.vue`)
The template gates everything behind `v-if=\"hasAllBuildingInformation\"`, but nothing observable signals \"data is loaded AND chapters have flushed to the DOM.\" Today the only signal PDF.co has is `networkidle`, which can fire before the template body has actually mounted.

**Fix**: set `[data-pdf-ready=\"true\"]` on `<html>` when `hasAllBuildingInformation` becomes true, after a `nextTick` so chapter rendering has completed. Cleared on unmount and on data going un-ready.

> **Operational follow-up**: PDF.co's render config should be updated to wait for the `html[data-pdf-ready=\"true\"]` selector instead of `networkidle`. Without that change this PR adds the signal but doesn't change behavior — strictly additive.

### 2. Mapbox `load` → `idle` (`src/components/Common/Mapbox/MapBox.vue`)
Was firing the `loaded` state on `map.on('load')`, which signals style + initial tile batch ready — but vector tile **features** may still be painting after that. Used by `LocationChapter`, `ConstructionYearChapter`, `IncidentsChapter`.

**Fix**: switched to `map.once('idle')` — strictly stronger (no in-flight tile requests, no animations, fully repainted). The `<slot v-if=\"loaded\" />` guard now mounts children only when the map is fully settled.

### 3. Chart.js `animation: false` in initial options (`BarChart.vue`, `ScatterChart.vue`)
Both were setting `chart.options.animation = false` **after** `new Chart(...)`. Chart.js has already started animating by then, so the very first paint still animated; only re-renders were static. Moved into the initial options object where it's evaluated on construction — first paint is now static, deterministic for headless capture.

`PieChart` already had this correct. `HorizontalBarChart` is just a wrapper over `BarChart`, so it inherits the fix.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [ ] Browser smoke test: web view of `/report/:buildingId` still renders correctly (charts show, maps render, no console errors from the slot-guard timing change)
- [ ] PDF render: capture a sample PDF off this branch and diff against current main — chapters should render identically; if the map ever rendered half-painted before, it should now be fully painted

## Out of scope

- Updating PDF.co's render config to use the new selector (operational change, not code).
- Bundle splitting (only matters if PDF.co ever hits a render timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)