### PR TITLE
chore(report): drop dead feedback.fundermaps.com / incident.fundermaps.com references

### DIFF
--- a/src/components/Print/Chapters/FoundationRestorationChapter.vue
+++ b/src/components/Print/Chapters/FoundationRestorationChapter.vue
@@ -103,13 +103,6 @@ const recoveryDate = computed(() => {
           </div>
         </div>
       </dl>
-      <p>
-        Wilt u uw pand aanmelden voor het funderingsherstelregister?
-        <a href="https://feedback.fundermaps.com/" target="_blank" rel="noopener noreferrer"
-          class="text-blue-600 underline hover:text-blue-800">
-          Klik hier om uw pand aan te melden
-        </a>.
-      </p>
     </section>
   </Chapter>
 </template>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,10 +4,6 @@
 
 export const apiBasePath = import.meta.env.VITE_FUNDERMAPS_URL || ''
 
-export const feedbackLink = 'https://feedback.fundermaps.com/building/' // + buildingId
-export const incidentLink = 'https://incident.fundermaps.com/'
-
-
 export const CHART_COLORS = {
   green: "rgb(40, 204, 139)",
   blue: "rgb(23, 164, 234)",

--- a/src/views/PDF.vue
+++ b/src/views/PDF.vue
@@ -239,14 +239,6 @@ onUnmounted(() => {
         <p>
           Meer informatie vindt u op de website van het Kennis Centrum Aanpak Funderingsproblematiek (KCAF): <a href="https://www.kcaf.nl/quickscan-risicobeoordeling/" target="_blank">https://www.kcaf.nl/quickscan-risicobeoordeling/</a>
         </p>
-
-        <strong class="block">Wijzigen of reageren?</strong>
-        <p>
-          Bent u het niet eens met de beoordeling, wilt u gegevens wijzigen of heeft u behoefte aan aanvullende informatie over dit funderingsrisicorapport? Dan kunt u terecht op: <a href="https://feedback.fundermaps.com/" target="_blank">https://feedback.fundermaps.com/</a>.
-        </p>
-        <p>
-          Hier kunt u eenvoudig een wijzigingsverzoek indienen of contact opnemen met ons team.
-        </p>
       </section>
     </article>
 


### PR DESCRIPTION
## Summary

Both domains no longer resolve (NXDOMAIN) but the report kept printing both URLs in customer-facing surfaces, sending recipients to dead destinations.

### Removed

- **`src/views/PDF.vue`** — the \"Wijzigen of reageren?\" section in the disclaimer block (strong header + 2 paragraphs) directing customers to `feedback.fundermaps.com`. **Visible on every PDF — primary customer-facing impact.**
- **`src/components/Print/Chapters/FoundationRestorationChapter.vue`** — the \"Wilt u uw pand aanmelden voor het funderingsherstelregister?\" CTA paragraph linking to `feedback.fundermaps.com`. That link looked misrouted from origin — it's a register-your-building CTA, not a feedback CTA. Removed the whole paragraph rather than redirecting, since there's no working destination yet.
- **`src/config/index.ts`** — `feedbackLink` and `incidentLink` constants. Both had **zero consumers** in `src/`. Pure dead config.

When the corrections / building-registration / incident-reporting flows get new canonical URLs, the surfaces can be restored with the new destinations.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] Zero remaining matches for `feedback.fundermaps.com`, `incident.fundermaps.com`, `feedbackLink`, or `incidentLink` in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)