### PR TITLE
fix(report): correct three typos in customer-visible field labels

### DIFF
--- a/src/datastructures/fieldLabels.ts
+++ b/src/datastructures/fieldLabels.ts
@@ -48,7 +48,7 @@ export const analysisFieldLabels = <Record<string, string>>{
   dewateringDepthRisk: "Ontwateringsdiepte risico",
   dewateringDepth: "Ontwateringsdiepte",
   dewateringDepthReliability: "Betrouwbaarheid ontwateringsdiepte",
-  bioInfectionRisk: "Bacterieelaantatsing risico",
+  bioInfectionRisk: "Bacteriële aantasting risico",
   bioInfectionReliability: "Betrouwbaarheid bacteriële aantasting",
   negativeclingRisk: "Negatieve kleef risico",
   negativeclingReliability: "Betrouwbaarheid Negatieve kleef",
@@ -148,7 +148,7 @@ export const inquirySampleFieldLabels = <Record<string, string>>{
   constructionType: "Materiaal funderingsbalk",
   woodCapacityHorizontalQuality: "Horizontale draagkracht paal",
   constructionQuality: "Funderingsbalk",
-  foundationDepth: "Fundeirngsnsniveau",
+  foundationDepth: "Funderingsniveau",
   constructionLevel: "Niveau onderkant funderingsbalk",
   woodLevel: "Niveau bovenkant langshout",
   masonLevel: "Niveau onderkant metselwerk",
@@ -200,8 +200,8 @@ export const riskFieldLabels = <Record<string, string>>{
   dewateringDepthRisk: "Ontwateringsdiepte risico",
   dewateringDepth: "Ontwateringsdiepte",
   dewateringDepthReliability: "Betrouwbaarheid ontwateringsdiepte",
-  bioInfectionRisk: "Bacterieelaantatsing risico",
-  bioInfectionReliability: "Betrouwbaarheid Bacterieel aantasting", // TODO: Typo in F150
+  bioInfectionRisk: "Bacteriële aantasting risico",
+  bioInfectionReliability: "Betrouwbaarheid bacteriële aantasting",
   // TODO: Missing field names: E152 - 156
   unclassifiedRisk: "Vastgesteld"
 }


### PR DESCRIPTION
## Summary

Three typos in `src/datastructures/fieldLabels.ts` that print on every PDF the customer receives:

| Variable | Before | After |
|---|---|---|
| \`bioInfectionRisk\` (lines 51 and 203) | \`Bacterieelaantatsing risico\` | \`Bacteriële aantasting risico\` |
| \`bioInfectionReliability\` (line 204) | \`Betrouwbaarheid Bacterieel aantasting\` | \`Betrouwbaarheid bacteriële aantasting\` |
| \`foundationDepth\` (line 151) | \`Fundeirngsnsniveau\` | \`Funderingsniveau\` |

The fix at line 204 also resolves the lingering \`// TODO: Typo in F150\` comment and aligns capitalisation with the equivalent label at line 52 (\`Betrouwbaarheid bacteriële aantasting\`, lowercase) so the same concept is rendered identically across the two label maps.

The \`F150\` / \`F135\` / \`E134-E138\` references in the file's comments point at an external field-spec document — they're not code in this repo and don't constrain the local copy. We control the user-visible string regardless of what the spec document says.

## Out of scope (deliberate)

While in this file I noticed two more inconsistencies worth a separate, opinion-driven PR:

- \`Betrouwbaarheid Negatieve kleef\` (line 54) and \`Betrouwbaarheid Verschilzakking\` (line 56) capitalise the second word, while every other \`Betrouwbaarheid X\` label uses lowercase \`x\`. Stylistic, but inconsistent.
- \`unclassifiedRisk: \"Vastgesteld\"\` (lines 57 and 206) maps \"unclassified\" to \"Vastgesteld\" (= \"established/determined\"). Looks like a translation bug — possibly should be \"Onbepaald\" or similar.

Leaving those for a follow-up since they involve copy decisions, not just typo fixes.

## Test plan

- [x] \`vue-tsc --noEmit\` clean
- [x] \`vite build\` clean
- [x] \`eslint src/\` clean
- [x] Zero remaining matches for \`Bacterieelaantatsing\`, \`Bacterieel aantasting\`, \`Fundeirng\`, or \`Funderingsnsniveau\` in \`src/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)