### PR TITLE
fix(report): consistent field-label copy — capitalisation + unclassifiedRisk relabel

### DIFF
--- a/src/datastructures/fieldLabels.ts
+++ b/src/datastructures/fieldLabels.ts
@@ -51,10 +51,10 @@ export const analysisFieldLabels = <Record<string, string>>{
   bioInfectionRisk: "Bacteriële aantasting risico",
   bioInfectionReliability: "Betrouwbaarheid bacteriële aantasting",
   negativeclingRisk: "Negatieve kleef risico",
-  negativeclingReliability: "Betrouwbaarheid Negatieve kleef",
+  negativeclingReliability: "Betrouwbaarheid negatieve kleef",
   differentialsettlementRisk: "Verschilzakking risico",
-  differentialsettlementReliability: "Betrouwbaarheid Verschilzakking",
-  unclassifiedRisk: "Vastgesteld",
+  differentialsettlementReliability: "Betrouwbaarheid verschilzakking",
+  unclassifiedRisk: "Algemeen risico",
   facadescanRisk: "Risico GevelScan"
 }
 
@@ -203,7 +203,7 @@ export const riskFieldLabels = <Record<string, string>>{
   bioInfectionRisk: "Bacteriële aantasting risico",
   bioInfectionReliability: "Betrouwbaarheid bacteriële aantasting",
   // TODO: Missing field names: E152 - 156
-  unclassifiedRisk: "Vastgesteld"
+  unclassifiedRisk: "Algemeen risico"
 }
 
 export const indicentFieldLabels = <Record<string, string>>{


### PR DESCRIPTION
## Summary

The two open copy questions from PR #37's description, decided.

### 1. Capitalisation consistency
Every other `Betrouwbaarheid X` label in the file uses lowercase X. These two were outliers:

| Line | Before | After |
|---|---|---|
| 54 | `Betrouwbaarheid Negatieve kleef` | `Betrouwbaarheid negatieve kleef` |
| 56 | `Betrouwbaarheid Verschilzakking` | `Betrouwbaarheid verschilzakking` |

Dutch doesn't capitalise common nouns; aligning with the convention.

### 2. `unclassifiedRisk` relabel: `\"Vastgesteld\"` → `\"Algemeen risico\"`

The `unclassifiedRisk` field maps from the API's `foundationRisk` field per `src/services/api/_adapters.ts:157` — it's the legacy single-bucket \"overall foundation risk\" that predates the split into drystand / dewatering / bioInfection.

The previous label `\"Vastgesteld\"` was misleading on two fronts:
- It doesn't describe what the field shows (an overall risk value, not a determination state).
- It **collides with the reliability tier `\"Vastgesteld\"`** used throughout the report. A customer seeing two unrelated things labeled identically has no way to tell them apart.

`\"Algemeen risico\"` (\"general/overall risk\") describes the actual semantic and removes the collision. If we ever decide a different framing is better, the change is one line per map.

Applied at lines 57 and 206 (the field appears in two label maps).

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)