### PR TITLE
feat(report): cover summary page on the customer PDF

### DIFF
--- a/src/components/Print/CoverSummary.vue
+++ b/src/components/Print/CoverSummary.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useAnalysisStore } from '@/store/building/analysis';
+import { useGeoLocationsStore } from '@/store/building/geolocations';
+import { useBuildingStore } from '@/store/buildings';
+
+import { EFoundationRisk, EFoundationRiskLabels } from '@/datastructures/enums';
+
+const { buildingId } = storeToRefs(useBuildingStore())
+const { getAnalysisDataByBuildingId } = useAnalysisStore()
+const { getLocationDataByBuildingId } = useGeoLocationsStore()
+
+const analysisData = computed(() => {
+  if (!buildingId.value) return null
+  return getAnalysisDataByBuildingId(buildingId.value)
+})
+
+const locationData = computed(() => {
+  if (!buildingId.value) return null
+  return getLocationDataByBuildingId(buildingId.value)
+})
+
+const fullAddress = computed(() => locationData.value?.address?.fullAddress || '—')
+
+const constructionYear = computed(() => analysisData.value?.constructionYear ?? '—')
+
+const foundationTypeLabel = computed(() => {
+  const label = analysisData.value?.foundationTypeLabel
+  return label && label.length > 0 ? label : '—'
+})
+
+// Headline risk = the worst category across all four risk fields. Higher
+// numeric enum value = higher risk on the A–E scale (A=0, E=4).
+const highestRiskLabel = computed(() => {
+  const a = analysisData.value
+  if (!a) return '—'
+  const risks = [a.drystandRisk, a.dewateringDepthRisk, a.bioInfectionRisk, a.unclassifiedRisk]
+    .filter((r): r is EFoundationRisk => r !== undefined && r !== null)
+  if (risks.length === 0) return 'Geen data'
+  const worst = Math.max(...risks) as EFoundationRisk
+  return EFoundationRiskLabels.get(worst) || 'Onbekend'
+})
+
+const externalBuildingId = computed(() => analysisData.value?.externalBuildingId || buildingId.value || '—')
+
+const generatedAt = computed(() =>
+  new Date().toLocaleDateString('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' })
+)
+</script>
+
+<template>
+  <article class="break-inside-avoid space-y-5">
+    <header class="space-y-1">
+      <p class="text-grey-700 text-sm uppercase tracking-wide">Pand</p>
+      <h2 class="text-grey-800 h-4">{{ fullAddress }}</h2>
+    </header>
+
+    <dl role="list" class="list--definition grid grid-cols-2 gap-x-8 gap-y-3 border-t border-grey-200 pt-5">
+      <div class="item--grid">
+        <dt>Bouwjaar</dt>
+        <dd>{{ constructionYear }}</dd>
+      </div>
+      <div class="item--grid">
+        <dt>Funderingstype</dt>
+        <dd>{{ foundationTypeLabel }}</dd>
+      </div>
+      <div class="item--grid">
+        <dt>Hoogste risicocategorie</dt>
+        <dd>{{ highestRiskLabel }}</dd>
+      </div>
+      <div class="item--grid">
+        <dt>BAG ID</dt>
+        <dd>{{ externalBuildingId }}</dd>
+      </div>
+    </dl>
+
+    <p class="text-grey-700 border-t border-grey-200 pt-3 text-sm">
+      Gegenereerd op {{ generatedAt }}
+    </p>
+  </article>
+</template>

--- a/src/views/PDF.vue
+++ b/src/views/PDF.vue
@@ -14,6 +14,7 @@ import { useStatisticsStore } from '@/store/building/statistics'
 import { useSubsidenceStore } from '@/store/building/subsidence';
 
 import PageBreak from '@/components/Print/PageBreak.vue'
+import CoverSummary from '@/components/Print/CoverSummary.vue'
 import BuildingChapter from '@/components/Print/Chapters/BuildingChapter.vue'
 import LocationChapter from '@/components/Print/Chapters/LocationChapter.vue';
 import InquirySampleChapter from '@/components/Print/Chapters/InquirySampleChapter.vue'
@@ -184,6 +185,9 @@ onUnmounted(() => {
         <h1>Funderingsrisicorapport</h1>
       </div>
     </header>
+
+    <CoverSummary />
+    <PageBreak />
 
     <BuildingChapter />
     <LocationChapter />


### PR DESCRIPTION
## Summary

Today the report opens with a logo + \"Funderingsrisicorapport\" title and jumps straight into BuildingChapter. A paying Dutch customer has to read 10 chapters to extract what they paid for.

This adds a one-page **cover summary** directly after the header — address (large), Bouwjaar / Funderingstype, Hoogste risicocategorie / BAG ID, plus a \"Gegenereerd op\" footer line. Followed by a PageBreak so chapters start on a fresh page.

```
Pand
De Veiling 38, 9603HN Hoogezand
─────────────────────────────────
Bouwjaar              Funderingstype
1971                  Houten palen
Hoogste risicocategorie   BAG ID
D (Hoog)              NL.IMBAG.PAND.0018100000044244
─────────────────────────────────
Gegenereerd op 2 mei 2026
```

## Implementation notes

- **New component** `src/components/Print/CoverSummary.vue`. Pulls from the same stores the chapters use (`analysis`, `geolocations`, `building`) so the page is gated by the existing `hasAllBuildingInformation` flag — no new readiness signal needed for PDF.co.
- **Hoogste risicocategorie** is computed as the worst (highest enum value) across `drystandRisk` / `dewateringDepthRisk` / `bioInfectionRisk` / `unclassifiedRisk`, rendered through `EFoundationRiskLabels` so it matches the labels used in `FoundationRiskChapter` (\"D (Hoog)\" etc.). Falls back to \"Geen data\" when all four are undefined, \"—\" when analysis hasn't loaded yet.
- **BAG ID** prefers `analysis.externalBuildingId` (the actual BAG identifier, e.g. `NL.IMBAG.PAND.…`) over the internal `buildingId`; falls back to `buildingId` if the external ID isn't on the payload.
- **Gegenereerd op** uses `toLocaleDateString('nl-NL')` with long month — \"2 mei 2026\" rather than \"02-05-2026\" — reads better in a deliverable.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] Confirmed all five cover labels (`Bouwjaar`, `Funderingstype`, `Hoogste risicocategorie`, `BAG ID`, `Gegenereerd op`) land in the built JS bundle
- [ ] Browser smoke + PDF render to confirm the cover sits cleanly above BuildingChapter and the typography hierarchy reads as a page-1 summary

## Out of scope (intentional follow-ups)

- The cover currently shows the **highest** risk only. A future enhancement could break it down per-risk with a small badge grid (\"Droogstand: D, Ontwateringsdiepte: C, ...\"); not done here to keep the cover focused on the headline.
- No reliability tier badge next to the headline risk yet — that depends on what the user wants to read first (worst risk, or worst-risk-with-confidence). Open question.
- No \"Volgende stappen\" CTA on the cover (deferred — that's PR I material; cover should stay focused on what-is-this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)