### PR TITLE
feat(report): front-of-report 'Hoe leest u dit rapport?' guide

### DIFF
--- a/src/components/Print/ReportGuide.vue
+++ b/src/components/Print/ReportGuide.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+// Front-of-report guide. Placed after CoverSummary so customers know how
+// to read the labels and colours BEFORE encountering them in chapters.
+//
+// The reliability tier definitions previously lived in the trailing
+// "Toelichting" article — moved here so terms are defined where they're
+// first needed.
+</script>
+
+<template>
+  <article class="break-inside-avoid space-y-7">
+    <header class="flex break-after-avoid items-center gap-2.5">
+      <h2 class="h-4">Hoe leest u dit rapport?</h2>
+    </header>
+
+    <section class="text-grey-700 space-y-4">
+      <p>
+        Dit funderingsrisicorapport bundelt onderzoeksgegevens, modelresultaten en metingen voor uw pand
+        en de directe omgeving. Hieronder staat kort uitgelegd hoe u de aanduidingen in de hoofdstukken
+        hierna leest.
+      </p>
+    </section>
+
+    <section class="space-y-3">
+      <strong class="text-grey-800 block">Risicocategorieën</strong>
+      <ol class="list--legenda">
+        <li style="--marker-color: #2e7d32"><strong>A</strong> — Geen risico</li>
+        <li style="--marker-color: #9e9d24"><strong>B</strong> — Laag risico</li>
+        <li style="--marker-color: #f9a825"><strong>C</strong> — Verhoogd risico</li>
+        <li style="--marker-color: #ef6c00"><strong>D</strong> — Hoog risico</li>
+        <li style="--marker-color: #c62828"><strong>E</strong> — Aanzienlijk hoog risico</li>
+      </ol>
+      <p class="text-grey-700">
+        De categorieën lopen van A (laagste) tot E (hoogste). Een hogere categorie betekent een grotere
+        kans op funderingsproblematiek — niet automatisch dat er nu al schade is.
+      </p>
+    </section>
+
+    <section class="text-grey-700 space-y-3">
+      <strong class="text-grey-800 block">Betrouwbaarheid</strong>
+      <p>
+        Bij elke beoordeling staat hoe betrouwbaar de uitkomst is. Dat hangt af van welke gegevens
+        beschikbaar zijn:
+      </p>
+      <ul class="space-y-2">
+        <li>
+          <strong>Vastgesteld:</strong> Er zijn specifieke onderzoeksgegevens beschikbaar voor dit pand
+          zelf. De betrouwbaarheid is hoog.
+        </li>
+        <li>
+          <strong>Afgeleid:</strong> Er zijn geen directe gegevens voor dit pand, maar wel voor
+          naastgelegen panden binnen dezelfde bouw- of funderingseenheid. Doorgaans goed onderbouwd,
+          omdat vergelijkbare constructies en omstandigheden gelden.
+        </li>
+        <li>
+          <strong>Modelmatig (indicatief):</strong> Er zijn geen gegevens van dit pand of de omliggende
+          panden. De uitkomst is een modelinschatting met een lagere betrouwbaarheid.
+        </li>
+      </ul>
+    </section>
+  </article>
+</template>

--- a/src/views/PDF.vue
+++ b/src/views/PDF.vue
@@ -15,6 +15,7 @@ import { useSubsidenceStore } from '@/store/building/subsidence';
 
 import PageBreak from '@/components/Print/PageBreak.vue'
 import CoverSummary from '@/components/Print/CoverSummary.vue'
+import ReportGuide from '@/components/Print/ReportGuide.vue'
 import BuildingChapter from '@/components/Print/Chapters/BuildingChapter.vue'
 import LocationChapter from '@/components/Print/Chapters/LocationChapter.vue';
 import InquirySampleChapter from '@/components/Print/Chapters/InquirySampleChapter.vue'
@@ -189,6 +190,9 @@ onUnmounted(() => {
     <CoverSummary />
     <PageBreak />
 
+    <ReportGuide />
+    <PageBreak />
+
     <BuildingChapter />
     <LocationChapter />
     <PageBreak />
@@ -214,26 +218,9 @@ onUnmounted(() => {
 
     <article class="space-y-5">
       <header class="flex break-after-avoid items-center gap-2.5">
-        <h2 class="h-4">Toelichting op het funderingsrisicorapport</h2>
+        <h2 class="h-4">Aanvullend onderzoek</h2>
       </header>
       <section class="space-y-4 text-grey-700">
-        <strong>Betrouwbaarheid</strong>
-        <p>
-          De betrouwbaarheid van het funderingsrisicorapport hangt af van de beschikbaarheid en aard van de onderliggende gegevens:
-        </p>
-        <ul>
-          <li>
-            <strong>Vastgesteld:</strong> Daar waar specifieke onderzoeksgegevens van het betreffende pand beschikbaar zijn, is de betrouwbaarheid van de uitgangspunten hoog. Het funderingstype en/of het funderingsrisico wordt dan als vastgesteld beschouwd.
-          </li>
-          <li>
-            <strong>Afgeleid:</strong> Wanneer er geen directe onderzoeksgegevens beschikbaar zijn voor het pand zelf, maar wel voor naastgelegen panden binnen dezelfde bouw- of funderingseenheid, wordt het funderingstype en de risicobeoordeling beschouwd als afgeleid. Deze afleiding is doorgaans goed onderbouwd, omdat vergelijkbare constructies en omstandigheden gelden.
-          </li>
-          <li>
-            <strong>Modelmatig (indicatief):</strong> Als er geen gegevens beschikbaar zijn van het pand zelf of van omliggende panden, wordt gebruikgemaakt van een modelanalyse. De uitkomsten daarvan zijn indicatief en hebben een lagere betrouwbaarheid.
-          </li>
-        </ul>
-
-        <strong class="block">Aanvullend onderzoek</strong>
         <p>
           Wanneer het risico op funderingsproblematiek verhoogd is en de databetrouwbaarheid als vastgesteld of afgeleid wordt beschouwd, kan een QuickScan uitkomst bieden. Zeker wanneer u – of een expert – op basis van zichtbare signalen zoals scheurvorming of scheefstand vermoedt dat daadwerkelijk sprake is van funderingsschade.
         </p>


### PR DESCRIPTION
## Summary

Today the reliability tier definitions (Vastgesteld / Afgeleid / Modelmatig) live only in the trailing \"Toelichting\" article — but the labels appear from chapter 1 onwards. A customer hits \"Betrouwbaarheid: Afgeleid\" without context and either guesses or flips to the back of the report. **The risk-colour scale (A green → E red) is never explained to the customer at all.**

This adds a new `ReportGuide` section right after `CoverSummary` (#39), before any chapter.

### Risicocategorieën — colour legend, A → E
- A — Geen risico (#2E7D32 green)
- B — Laag risico (#9E9D24 olive)
- C — Verhoogd risico (#F9A825 yellow)
- D — Hoog risico (#EF6C00 orange)
- E — Aanzienlijk hoog risico (#C62828 red)

Colours pulled from the existing classification SVG palette in `src/assets/svg/icons/classification/{a..e}.svg` — verified by grepping the `fill` values directly so the legend can't drift out of sync with the icons.

### Betrouwbaarheid — tier definitions, moved from the trailer
**Vastgesteld / Afgeleid / Modelmatig** definitions moved out of the trailing \"Toelichting\" article into the new ReportGuide. Subtle copy edits during the move so the prose anchors to *\"this pand\"* rather than *\"the pand\"* — reads a step more natural applied to the customer's own building.

### Trailing article retitled
\"Toelichting op het funderingsrisicorapport\" → \"Aanvullend onderzoek\" (the only remaining content there is the QuickScan / KCAF reference).

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] Built bundle contains `Hoe leest u dit rapport`, `Risicocategorieën`, `Aanzienlijk hoog risico`, `Aanvullend onderzoek`
- [ ] Browser smoke + PDF render to confirm typography hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)