### PR TITLE
refactor(report): match chapter style for CoverSummary + ReportGuide

### DIFF
--- a/src/components/Print/CoverSummary.vue
+++ b/src/components/Print/CoverSummary.vue
@@ -2,6 +2,8 @@
 import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 
+import Chapter from '@/components/Print/Chapter.vue'
+
 import { useAnalysisStore } from '@/store/building/analysis';
 import { useGeoLocationsStore } from '@/store/building/geolocations';
 import { useBuildingStore } from '@/store/buildings';
@@ -51,33 +53,34 @@ const generatedAt = computed(() =>
 </script>
 
 <template>
-  <article class="break-inside-avoid space-y-5">
-    <header class="space-y-1">
-      <p class="text-grey-700 text-sm uppercase tracking-wide">Pand</p>
-      <h2 class="text-grey-800 h-4">{{ fullAddress }}</h2>
-    </header>
+  <Chapter icon="home-info" title="Samenvatting">
+    <section class="space-y-7">
+      <dl role="list" class="list--definition">
+        <div class="item justify-between">
+          <dt>Adres</dt>
+          <dd>{{ fullAddress }}</dd>
+        </div>
+        <div class="item justify-between">
+          <dt>Bouwjaar</dt>
+          <dd>{{ constructionYear }}</dd>
+        </div>
+        <div class="item justify-between">
+          <dt>Funderingstype</dt>
+          <dd>{{ foundationTypeLabel }}</dd>
+        </div>
+        <div class="item justify-between">
+          <dt>Hoogste risicocategorie</dt>
+          <dd>{{ highestRiskLabel }}</dd>
+        </div>
+        <div class="item justify-between">
+          <dt>BAG ID</dt>
+          <dd>{{ externalBuildingId }}</dd>
+        </div>
+      </dl>
 
-    <dl role="list" class="list--definition grid grid-cols-2 gap-x-8 gap-y-3 border-t border-grey-200 pt-5">
-      <div class="item--grid">
-        <dt>Bouwjaar</dt>
-        <dd>{{ constructionYear }}</dd>
-      </div>
-      <div class="item--grid">
-        <dt>Funderingstype</dt>
-        <dd>{{ foundationTypeLabel }}</dd>
-      </div>
-      <div class="item--grid">
-        <dt>Hoogste risicocategorie</dt>
-        <dd>{{ highestRiskLabel }}</dd>
-      </div>
-      <div class="item--grid">
-        <dt>BAG ID</dt>
-        <dd>{{ externalBuildingId }}</dd>
-      </div>
-    </dl>
-
-    <p class="text-grey-700 border-t border-grey-200 pt-3 text-sm">
-      Gegenereerd op {{ generatedAt }}
-    </p>
-  </article>
+      <p class="text-grey-700 text-sm">
+        Gegenereerd op {{ generatedAt }}
+      </p>
+    </section>
+  </Chapter>
 </template>

--- a/src/components/Print/ReportGuide.vue
+++ b/src/components/Print/ReportGuide.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import Chapter from '@/components/Print/Chapter.vue'
+
 // Front-of-report guide. Placed after CoverSummary so customers know how
 // to read the labels and colours BEFORE encountering them in chapters.
 //
@@ -8,55 +10,51 @@
 </script>
 
 <template>
-  <article class="break-inside-avoid space-y-7">
-    <header class="flex break-after-avoid items-center gap-2.5">
-      <h2 class="h-4">Hoe leest u dit rapport?</h2>
-    </header>
-
-    <section class="text-grey-700 space-y-4">
-      <p>
-        Dit funderingsrisicorapport bundelt onderzoeksgegevens, modelresultaten en metingen voor uw pand
-        en de directe omgeving. Hieronder staat kort uitgelegd hoe u de aanduidingen in de hoofdstukken
-        hierna leest.
-      </p>
-    </section>
-
-    <section class="space-y-3">
-      <strong class="text-grey-800 block">Risicocategorieën</strong>
-      <ol class="list--legenda">
-        <li style="--marker-color: #2e7d32"><strong>A</strong> — Geen risico</li>
-        <li style="--marker-color: #9e9d24"><strong>B</strong> — Laag risico</li>
-        <li style="--marker-color: #f9a825"><strong>C</strong> — Verhoogd risico</li>
-        <li style="--marker-color: #ef6c00"><strong>D</strong> — Hoog risico</li>
-        <li style="--marker-color: #c62828"><strong>E</strong> — Aanzienlijk hoog risico</li>
-      </ol>
+  <Chapter icon="info" title="Hoe leest u dit rapport?">
+    <section class="space-y-7">
       <p class="text-grey-700">
-        De categorieën lopen van A (laagste) tot E (hoogste). Een hogere categorie betekent een grotere
-        kans op funderingsproblematiek — niet automatisch dat er nu al schade is.
+        Dit funderingsrisicorapport bundelt onderzoeksgegevens, modelresultaten en metingen voor uw
+        pand en de directe omgeving. Hieronder staat kort uitgelegd hoe u de aanduidingen in de
+        hoofdstukken hierna leest.
       </p>
-    </section>
 
-    <section class="text-grey-700 space-y-3">
-      <strong class="text-grey-800 block">Betrouwbaarheid</strong>
-      <p>
-        Bij elke beoordeling staat hoe betrouwbaar de uitkomst is. Dat hangt af van welke gegevens
-        beschikbaar zijn:
-      </p>
-      <ul class="space-y-2">
-        <li>
-          <strong>Vastgesteld:</strong> Er zijn specifieke onderzoeksgegevens beschikbaar voor dit pand
-          zelf. De betrouwbaarheid is hoog.
-        </li>
-        <li>
-          <strong>Afgeleid:</strong> Er zijn geen directe gegevens voor dit pand, maar wel voor
-          naastgelegen panden binnen dezelfde bouw- of funderingseenheid. Doorgaans goed onderbouwd,
-          omdat vergelijkbare constructies en omstandigheden gelden.
-        </li>
-        <li>
-          <strong>Modelmatig (indicatief):</strong> Er zijn geen gegevens van dit pand of de omliggende
-          panden. De uitkomst is een modelinschatting met een lagere betrouwbaarheid.
-        </li>
-      </ul>
+      <div class="space-y-3">
+        <strong class="text-grey-800 block">Risicocategorieën</strong>
+        <ol class="list--legenda">
+          <li style="--marker-color: #2e7d32"><strong>A</strong> — Geen risico</li>
+          <li style="--marker-color: #9e9d24"><strong>B</strong> — Laag risico</li>
+          <li style="--marker-color: #f9a825"><strong>C</strong> — Verhoogd risico</li>
+          <li style="--marker-color: #ef6c00"><strong>D</strong> — Hoog risico</li>
+          <li style="--marker-color: #c62828"><strong>E</strong> — Aanzienlijk hoog risico</li>
+        </ol>
+        <p class="text-grey-700">
+          De categorieën lopen van A (laagste) tot E (hoogste). Een hogere categorie betekent een
+          grotere kans op funderingsproblematiek — niet automatisch dat er nu al schade is.
+        </p>
+      </div>
+
+      <div class="text-grey-700 space-y-3">
+        <strong class="text-grey-800 block">Betrouwbaarheid</strong>
+        <p>
+          Bij elke beoordeling staat hoe betrouwbaar de uitkomst is. Dat hangt af van welke gegevens
+          beschikbaar zijn:
+        </p>
+        <ul class="space-y-2">
+          <li>
+            <strong>Vastgesteld:</strong> Er zijn specifieke onderzoeksgegevens beschikbaar voor dit
+            pand zelf. De betrouwbaarheid is hoog.
+          </li>
+          <li>
+            <strong>Afgeleid:</strong> Er zijn geen directe gegevens voor dit pand, maar wel voor
+            naastgelegen panden binnen dezelfde bouw- of funderingseenheid. Doorgaans goed onderbouwd,
+            omdat vergelijkbare constructies en omstandigheden gelden.
+          </li>
+          <li>
+            <strong>Modelmatig (indicatief):</strong> Er zijn geen gegevens van dit pand of de
+            omliggende panden. De uitkomst is een modelinschatting met een lagere betrouwbaarheid.
+          </li>
+        </ul>
+      </div>
     </section>
-  </article>
+  </Chapter>
 </template>


### PR DESCRIPTION
## Summary

Yorick flagged that the cover article (#39) and the report guide (#40) used custom `<article class=\"break-inside-avoid space-y-5\">` wrappers that didn't match the rest of the report. Every existing chapter routes through `src/components/Print/Chapter.vue`, which gives a consistent **icon + `<h2 class=\"h-4\">` header + `space-y-5` skeleton + `<section class=\"space-y-7\">` body**. That's the visual standard.

Both new sections now wrap with `<Chapter title=\"...\" icon=\"...\">` and put their content in the slot, so they pick up the same header rule and spacing as the chapters that follow.

| Component | Icon | Title | Notes |
|---|---|---|---|
| `CoverSummary` | `home-info` | `Samenvatting` | Renamed from a custom \"Pand\" pre-header so it doesn't collide with `BuildingChapter`'s \"Pand\" title. \"Samenvatting\" also reads more naturally for an at-a-glance overview. |
| `ReportGuide` | `info` | `Hoe leest u dit rapport?` | Heading was already correct; just routed through the wrapper. |

In `CoverSummary`, the address is now the first `<dl>` row alongside Bouwjaar / Funderingstype / Hoogste risicocategorie / BAG ID — same data, presented chapter-natively rather than as a styled stand-alone heading.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] Bundle still contains `Samenvatting`, `Hoe leest u dit rapport`, `Risicocategorieën`, `Aanzienlijk hoog risico`, `Aanvullend onderzoek`, `Hoogste risicocategorie`, `Adres`
- [ ] PDF render to confirm Samenvatting + Hoe leest u dit rapport now read as part of the same visual family as Pand / Locatie / Funderingsrisico / etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)