### PR TITLE
feat(report): plain-language intros for the six bare-data chapters

### DIFF
--- a/src/components/Print/Chapters/BuildingChapter.vue
+++ b/src/components/Print/Chapters/BuildingChapter.vue
@@ -73,6 +73,13 @@ const fieldsWithData = computed(() => {
 <template>
   <Chapter icon="building" title="Pand">
     <section class="space-y-7">
+      <div class="text-grey-700">
+        <p>
+          Dit hoofdstuk toont de basisgegevens van uw pand uit het Basisregistratie Adressen en Gebouwen
+          (BAG): adres, oppervlakte, hoogte en het BAG-pandnummer. Deze gegevens vormen de basis voor
+          de risicobeoordelingen verderop in het rapport.
+        </p>
+      </div>
       <dl role="list" class="list--definition">
         <div v-for="field in fieldsWithData" :key="field.name" class="item justify-between">
           <dt>{{ field.label }}</dt>

--- a/src/components/Print/Chapters/ConstructionYearChapter.vue
+++ b/src/components/Print/Chapters/ConstructionYearChapter.vue
@@ -163,6 +163,14 @@ const legendItems = [
 <template>
   <Chapter icon="building" title="Bouwjaar">
     <section class="space-y-7">
+      <div class="text-grey-700">
+        <p>
+          Het bouwjaar bepaalt vaak het funderingstype en daarmee het risicoprofiel: panden van vóór
+          1960 staan in Nederland veelal op houten palen, die gevoelig zijn voor droogstand en
+          bacteriële aantasting. Hieronder ziet u in welke periode uw pand is gebouwd en hoe dat
+          zich verhoudt tot de panden in uw wijk.
+        </p>
+      </div>
       <div v-if="constructionGraph.data.length !== 0" class="chart | grid grid-cols-12 items-center gap-4">
         <BarChart class="w-full" title="Bouwjaren (wijk)" :data="constructionGraph.data"
           :labels="constructionGraph.labels" gradient />

--- a/src/components/Print/Chapters/FacadeReviewChapter.vue
+++ b/src/components/Print/Chapters/FacadeReviewChapter.vue
@@ -134,6 +134,14 @@ const sampleFieldsWithData: ComputedRef<Record<string, CompletedFieldData[]>> = 
   <Chapter v-if="hasSampleData" icon="scan" title="Gevelscan">
 
     <section class="space-y-7">
+      <div class="text-grey-700 space-y-4">
+        <p>
+          De gevelscan registreert zichtbare aanwijzingen van funderingsproblematiek aan de buitenkant
+          van het pand: scheurvorming, scheefstand en vervorming. Een lintvoegmeting registreert
+          horizontale vervorming, een loodmeting verticale scheefstand. Deze metingen vullen de
+          modelmatige risicobeoordelingen aan met directe waarnemingen op locatie.
+        </p>
+      </div>
       <div class="grid grid-cols-2 gap-4"
         v-if="(groupHasData['indoor'] || groupHasData['left'] || groupHasData['right'] || groupHasData['front'] || groupHasData['back'])">
         <div class="grid grid-cols-6 items-center gap-4">

--- a/src/components/Print/Chapters/FoundationRestorationChapter.vue
+++ b/src/components/Print/Chapters/FoundationRestorationChapter.vue
@@ -72,10 +72,14 @@ const recoveryDate = computed(() => {
   <Chapter icon="wrench" title="Funderingsherstel">
 
     <section class="space-y-7">
-      <div class="text-gray-700">
+      <div class="text-grey-700 space-y-4">
         <p>
-          Vanuit het Nationaal Funderingsherstelregister is de volgende informatie beschikbaar over het herstel van het
-          pand:
+          Hieronder ziet u of er aan de fundering van dit pand al herstelwerk is uitgevoerd, en zo ja,
+          welk type en wanneer. Een eerder herstel kan duiden op eerdere problematiek; de huidige
+          risicobeoordelingen verderop in het rapport gelden onafhankelijk daarvan.
+        </p>
+        <p>
+          De gegevens hieronder zijn afkomstig uit het Nationaal Funderingsherstelregister.
         </p>
       </div>
       <dl role="list" class="list--definition">

--- a/src/components/Print/Chapters/LocationChapter.vue
+++ b/src/components/Print/Chapters/LocationChapter.vue
@@ -131,6 +131,14 @@ const addMarker = function addMarker({ map }: { map: Map }) {
 <template>
   <Chapter icon="pin" title="Locatie">
     <section class="space-y-7">
+      <div class="text-grey-700">
+        <p>
+          De ondergrond bepaalt grotendeels het funderingsrisico van een pand. Hieronder ziet u welk
+          type bodem onder uw pand zit, hoe diep het grondwater staat, en hoe uw pand binnen de
+          bouweenheid en wijk ligt. Een hoge grondwaterstand vergroot bijvoorbeeld het risico op
+          houtrot bij houten paalfunderingen.
+        </p>
+      </div>
       <div class="aspect-map w-full overflow-clip">
         <MapBox class="asp w-full object-cover" :options="mapOptions" @load="addMarker" />
       </div>

--- a/src/components/Print/Chapters/ReportingChapter.vue
+++ b/src/components/Print/Chapters/ReportingChapter.vue
@@ -54,9 +54,17 @@ const reportGraph = computed(() => {
   <Chapter v-if="inquiryData.length || reportGraph.data.length" icon="file-report" title="Rapportage">
 
     <section class="break-before-avoid-page break-inside-avoid space-y-7">
+      <div class="text-grey-700 space-y-4">
+        <p>
+          Onder de risicobeoordelingen in dit rapport liggen onderzoeksrapportages voor uw pand of
+          voor panden in de directe omgeving. Hieronder vindt u welke rapportages zijn meegenomen, en
+          hoeveel onderzoeken er per jaar in uw wijk zijn uitgevoerd — meer onderzoeken in uw buurt
+          geven over het algemeen een betrouwbaardere modelinschatting.
+        </p>
+      </div>
       <p v-if="inquiryData.length !== 0">
-        De volgende rapportage(s) zijn beschikbaar voor dit pand en zijn gebruikt voor het opstellen van het
-        funderingsrisicorapport
+        De volgende rapportage(s) zijn beschikbaar voor dit pand en zijn gebruikt voor het opstellen
+        van het funderingsrisicorapport.
       </p>
       <table v-if="inquiryData.length !== 0" class="w-full">
         <thead>


### PR DESCRIPTION
## Summary

Customers were paying for the *interpretation*, not raw data — but six chapters opened straight into a `<dl>` of label/value pairs with no context. Adds a 1–3 sentence Dutch intro at the top of each section explaining what the chapter shows and why it matters for foundation risk. Matches the prose style already used by `InquirySampleChapter` and `DisplacementDataChapter` (`text-grey-700` wrapper, short paragraphs).

| Chapter | Intro framing |
|---|---|
| `BuildingChapter` | basisgegevens uit het BAG vormen de basis voor de risicobeoordelingen |
| `LocationChapter` | de ondergrond bepaalt grotendeels het funderingsrisico; hoge grondwaterstand verhoogt houtrot-risico |
| `ConstructionYearChapter` | bouwjaar bepaalt vaak het funderingstype; vóór 1960 veelal houten palen |
| `FoundationRestorationChapter` | eerder herstel kan duiden op eerdere problematiek; huidige beoordelingen gelden onafhankelijk |
| `ReportingChapter` | meer onderzoeken in de buurt geven een betrouwbaardere modelinschatting |
| `FacadeReviewChapter` | gevelscan vult de modelmatige beoordelingen aan met directe waarnemingen op locatie; lintvoeg = horizontaal, lood = verticaal |

The copy is calibrated for a Dutch homeowner / real-estate buyer, not a foundation specialist. Open to wording iteration — the structure (one intro paragraph per chapter, top of section) matters more than the exact phrasing.

## Out of scope (intentional)

- `FoundationRiskChapter` already has good per-risk prose, but no top-level \"how to read this chapter\" framing. That chapter has 5 sub-sections each deserving its own context bridge — bigger scope, deferred to a separate PR.
- No \"volgende stappen / wat nu?\" closers per finding yet (PR I).
- No risk-icon legend embedded next to each FoundationRiskChapter sub-section (the front-of-report `ReportGuide` from #40/#41 covers this once, but a small inline reminder per sub-section may be a follow-up).

## Drive-by

Fixed `text-gray-700` → `text-grey-700` in `FoundationRestorationChapter.vue`. The `@theme` block in `src/style.css` declares `--color-*: initial`, which resets the default Tailwind gray scale — only the project's custom `grey-*` palette resolves. So the existing `text-gray-700` was falling back to the inherited color, not the intended `#7f8fa4`. Same drift class as the `&--definition` and `theme()` issues we cleaned up earlier.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] All six distinguishing phrases verified in the built bundle
- [ ] PDF render to confirm typography reads as a chapter intro paragraph (not a callout block) and the prose colour matches the existing `text-grey-700` body copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)