### PR TITLE
feat(report): risk-stratified 'Volgende stappen' closer per FoundationRiskChapter finding

### DIFF
--- a/src/components/Print/Chapters/FoundationRiskChapter.vue
+++ b/src/components/Print/Chapters/FoundationRiskChapter.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia';
 
 import Chapter from '@/components/Print/Chapter.vue'
 import ClassificationIcon from '@/components/Common/Icons/ClassificationIcon.vue'
+import RiskNextSteps from '@/components/Print/RiskNextSteps.vue'
 import PieChart from '@/components/Charts/PieChart.vue'
 
 import { retrieveAndFormatFieldData, FieldDataConfig, applyContextToFieldDataConfigs, CompletedFieldData } from '@/utils/fieldData'
@@ -150,6 +151,7 @@ const graphData = computed(() => {
             </p>
           </div>
         </div>
+        <RiskNextSteps :level="fieldsWithDataAndIcons.drystandRisk?.icon" />
       </div>
 
       <!-- RISK: Ontwateringsdiepte (Optrekkend vocht & Verschilzakking) -->
@@ -191,6 +193,7 @@ const graphData = computed(() => {
             </p>
           </div>
         </div>
+        <RiskNextSteps :level="fieldsWithDataAndIcons.dewateringDepthRisk?.icon" />
       </div>
       <div v-if="fieldsWithDataAndIcons.dewateringDepthRisk?.icon" class="risk break-inside-avoid space-y-5">
         <div class="space-y-2">
@@ -233,6 +236,7 @@ const graphData = computed(() => {
             </p>
           </div>
         </div>
+        <RiskNextSteps :level="fieldsWithDataAndIcons.dewateringDepthRisk?.icon" />
       </div>
 
       <!-- RISK: Bacteriële aantasting -->
@@ -270,6 +274,7 @@ const graphData = computed(() => {
             </p>
           </div>
         </div>
+        <RiskNextSteps :level="fieldsWithDataAndIcons.bioInfectionRisk?.icon" />
       </div>
 
       <div class="grid grid-cols-2 gap-4">

--- a/src/components/Print/RiskNextSteps.vue
+++ b/src/components/Print/RiskNextSteps.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+// Risk-stratified "Volgende stappen" closer for each finding inside
+// FoundationRiskChapter. Takes the icon level produced by retrieveAndFormatFieldData
+// (a / b / c / d / e — same letters used for the ClassificationIcon SVGs)
+// and shows guidance scaled to the severity:
+//
+//   A / B  → low  — observe, no action needed
+//   C      → medium — stay alert, QuickScan if circumstances change
+//   D / E  → high — recommend KCAF QuickScan now
+const props = defineProps<{
+  level?: string | null
+}>()
+
+const tone = computed<'low' | 'medium' | 'high' | null>(() => {
+  if (!props.level) return null
+  const l = props.level.toLowerCase()
+  if (l === 'a' || l === 'b') return 'low'
+  if (l === 'c') return 'medium'
+  if (l === 'd' || l === 'e') return 'high'
+  return null
+})
+</script>
+
+<template>
+  <aside v-if="tone" class="text-grey-700 border-t border-grey-200 space-y-2 pt-3">
+    <strong class="text-grey-800 block">Volgende stappen</strong>
+    <p v-if="tone === 'low'">
+      Het risico is laag. Een aanvullend onderzoek is op dit moment meestal niet nodig. Houd het
+      pand wel in de gaten op zichtbare signalen — scheurvorming, klemmende ramen of deuren,
+      zichtbare verzakkingen — en raadpleeg dit rapport opnieuw als die zich voordoen of bij een
+      ingrijpende verbouwing.
+    </p>
+    <p v-else-if="tone === 'medium'">
+      Het risico is verhoogd. Acute maatregelen zijn nu meestal nog niet nodig, maar het is
+      verstandig om alert te blijven op zichtbare signalen (scheurvorming, vocht, scheefstand). Bij
+      twijfel — of bij verkoop of verbouwing van het pand — is een KCAF QuickScan een goede
+      vervolgstap (zie hoofdstuk Aanvullend onderzoek).
+    </p>
+    <p v-else>
+      Het risico is hoog. Wij adviseren een <strong>KCAF QuickScan</strong> als vervolgstap — een
+      relatief snelle en betaalbare beoordeling die uitwijst of aanvullend funderingsonderzoek op
+      locatie nodig is (zie hoofdstuk Aanvullend onderzoek). Bij zichtbare schade aan de gevel of
+      constructie is een specialistisch funderingsonderzoek aangewezen.
+    </p>
+  </aside>
+</template>


### PR DESCRIPTION
## Summary

Today the only \"what to do next\" guidance the report offers is one mention of the KCAF QuickScan in the trailing \"Aanvullend onderzoek\" article — detached from the risk findings and identical regardless of severity. Two customers seeing wildly different risk levels both got the same advice, and many didn't realise the trailing reference applied to *their* situation.

This adds a small **Volgende stappen** closer at the bottom of each of the four risk sub-sections in `FoundationRiskChapter` (Droogstand, Optrekkend vocht, Verschilzakking, Bacteriële aantasting), with three distinct tones scaled to the risk level:

| Level | Tone | Guidance |
|---|---|---|
| **A / B** | low | Observe, no action needed; monitor for visible signals (cracks, sticking doors, visible subsidence); re-consult on changes or major renovations. |
| **C** | medium | Stay alert to visible signals; KCAF QuickScan is a sensible step at sale or renovation time. |
| **D / E** | high | Recommend a KCAF QuickScan as the explicit next step (relatively quick + affordable); specialist foundation investigation if visible damage exists. |

Each tone references the back-of-report \"Aanvullend onderzoek\" chapter where the QuickScan + KCAF link lives, so the closer hooks customers into the existing canonical reference rather than duplicating it.

## Implementation

- **New component** `src/components/Print/RiskNextSteps.vue`. Takes a `level` prop matching the icon name produced by `retrieveAndFormatFieldData` (`a` / `b` / `c` / `d` / `e` — same letters as the ClassificationIcon SVGs), so the chapter can pass `:level=\"fieldsWithDataAndIcons.X?.icon\"` directly without threading the raw `EFoundationRisk` enum through.
- Renders nothing when level is missing.
- Visually a top-bordered `<aside>` so it reads as a closer, not as another paragraph of explanatory prose.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] All three tones present in the bundle (`Het risico is laag` / `verhoogd` / `hoog`); `Volgende stappen` heading present; `KCAF QuickScan` referenced twice (medium + high)
- [ ] PDF render across a range of buildings (mix of A → E findings) to confirm the right tone fires for each risk

## Out of scope

- The closer doesn't currently link out to KCAF directly — it points to the back-of-report chapter. If we want a clickable link in the PDF, that's a follow-up (the back-of-report chapter has the canonical URL).
- No closer on the trailing wijk-overview pie chart (that's wijk-level statistics, not a per-risk finding for *this* building).
- Copy is opinion-driven; happy to iterate on phrasing — the structure (one closer per finding, three tones) is the load-bearing part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)