### PR TITLE
feat(report): top-level intro for FoundationRiskChapter

### DIFF
--- a/src/components/Print/Chapters/FoundationRiskChapter.vue
+++ b/src/components/Print/Chapters/FoundationRiskChapter.vue
@@ -115,6 +115,21 @@ const graphData = computed(() => {
   <Chapter icon="alert" title="Funderingsrisico">
 
     <section class="space-y-7">
+      <div class="text-grey-700 space-y-4">
+        <p>
+          Hieronder vindt u per risicotype een beoordeling voor uw pand: droogstand, optrekkend
+          vocht, verschilzakking en bacteriële aantasting. Elk risico wordt afzonderlijk gewogen op
+          basis van de beschikbare gegevens en kan verschillende oorzaken hebben — een laag risico
+          op het ene type sluit een hoger risico op een ander niet uit.
+        </p>
+        <p>
+          Bij elk risico staat een categorie van A (laagste) tot E (hoogste) en een betrouwbaarheid
+          (Vastgesteld, Afgeleid of Modelmatig). Zie het hoofdstuk Hoe leest u dit rapport? voor de
+          uitleg van beide. Onderaan dit hoofdstuk ziet u hoe uw pand zich verhoudt tot de panden in
+          uw wijk.
+        </p>
+      </div>
+
       <!-- RISK: Droogstand -->
       <div v-if="fieldsWithDataAndIcons.drystandRisk?.icon" class="risk break-inside-avoid space-y-5">
         <div class="space-y-2">


### PR DESCRIPTION
## Summary

Deferred from #42 (intros for the six bare-data chapters) because `FoundationRiskChapter` has its own per-risk prose and a wijk-level overview at the end — it deserved a top-level frame, not the generic intro the others got.

Adds a 2-paragraph header at the top of the chapter that:

1. **Lists the four risk types up front** (droogstand, optrekkend vocht, verschilzakking, bacteriële aantasting) so the customer sees the scope before scrolling.
2. **Calls out that risks are independent** — low on one doesn't mean low on another. This wasn't said anywhere in the report and is the most common misread of a foundation risk report.
3. **Reminds the customer where the A–E categories and Vastgesteld/Afgeleid/Modelmatig tiers are defined** (\"Hoe leest u dit rapport?\" — the ReportGuide on page 2 from #40/#41), so the customer who skipped page 2 has a pointer.
4. **Notes the wijk comparison sits at the end of the chapter**, so the customer doesn't bail out of the chapter before reaching it.

Style follows the established chapter-intro pattern (text-grey-700 wrapper, space-y-4 between paragraphs, top of section).

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] Built bundle contains `Hieronder vindt u per risicotype`, `een laag risico`, and `Hoe leest u dit rapport` appears twice (ReportGuide title + this PR's pointer-back reference)
- [ ] PDF render to confirm the intro reads as a chapter frame, not as another paragraph between findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)