### PR TITLE
feat(report): '1 of N' disclosure in InquirySampleChapter for multi-inquiry buildings

### DIFF
--- a/src/components/Print/Chapters/InquirySampleChapter.vue
+++ b/src/components/Print/Chapters/InquirySampleChapter.vue
@@ -87,6 +87,22 @@ const inquiryData: ComputedRef<ICombinedInquiryData[]> = computed(() => {
   return getCombinedInquiryDataByBuildingId(buildingId.value) || []
 })
 
+// "1 of N" disclosure: this chapter shows fields from inquiryData[0]?.sample,
+// which the store sorts most-recent-first. When more than one inquiry has a
+// sample for this building, surface the date of the one we're rendering and
+// tell the customer the rest live in the Rapportage chapter — otherwise a
+// silent pick of the first sample is misleading on multi-inquiry buildings.
+const samplesAvailableCount = computed(
+  () => inquiryData.value.filter((entry) => entry.sample !== undefined).length
+)
+const selectedReportDateLabel = computed(() => {
+  const raw = inquiryData.value[0]?.report?.documentDate
+  if (!raw) return null
+  const d = new Date(raw)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleDateString('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' })
+})
+
 
 
 /**
@@ -238,6 +254,12 @@ const foundationTypeGraph = computed(() => {
 <template>
   <Chapter icon="file-foundation" title="Fundering">
     <section class="space-y-7">
+      <p v-if="samplesAvailableCount > 1" class="text-grey-700">
+        Voor dit pand zijn {{ samplesAvailableCount }} onderzoeksrapporten met monsters
+        beschikbaar. Hieronder ziet u de gegevens uit het meest recente rapport<template v-if="selectedReportDateLabel">
+          ({{ selectedReportDateLabel }})</template>; het volledige overzicht vindt u in het
+        hoofdstuk Rapportage.
+      </p>
       <div class="grid grid-cols-12 gap-4">
         <figure v-if="foundationIconName"
           class="col-span-3 flex aspect-square flex-col items-center gap-1 rounded border border-grey-400 p-4">


### PR DESCRIPTION
## Summary

Closes the multi-sample story I opened in #31. That PR made the sample selection deterministic (`inquiryData[0]?.sample` after sort by `documentDate` desc); this one tells the *customer* what they're looking at.

For single-inquiry buildings: nothing changes (the disclosure is gated on `> 1`). For multi-inquiry buildings, the chapter now opens with:

> Voor dit pand zijn **N** onderzoeksrapporten met monsters beschikbaar. Hieronder ziet u de gegevens uit het meest recente rapport **(15 mei 2020)**; het volledige overzicht vindt u in het hoofdstuk Rapportage.

## Implementation

- `samplesAvailableCount` filters `inquiryData` entries on `entry.sample !== undefined` so inquiries without samples don't inflate the count (the store returns those entries too — the chapter can't render them, so we don't promise N of them).
- `selectedReportDateLabel` degrades gracefully: NaN/missing `documentDate` falls through and the parenthetical is skipped, so we never print `(Invalid Date)` or similar artifact.
- Points to the existing Rapportage chapter (which already lists every report in a table) rather than duplicating the list here.
- Singular case (one inquiry) renders nothing — would just be visual noise.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] Bundle contains `onderzoeksrapporten met monsters`, `het meest recente rapport`, `hoofdstuk Rapportage`
- [ ] PDF render against (a) a single-inquiry building — disclosure should NOT appear, (b) a multi-inquiry building — disclosure with the right N and most-recent date

🤖 Generated with [Claude Code](https://claude.com/claude-code)