### PR TITLE
fix(report): snapshot Mapbox canvas to PNG so the map renders in PDF output

### DIFF
--- a/src/components/Common/Mapbox/MapBox.vue
+++ b/src/components/Common/Mapbox/MapBox.vue
@@ -29,6 +29,15 @@ const loaded = ref(false)
 provide('loaded', readonly(loaded))
 
 /**
+ * Static PNG snapshot of the rendered canvas. We swap the live WebGL canvas
+ * out for an <img> as soon as the map has settled, because headless Chrome's
+ * print pipeline doesn't reliably capture WebGL canvases — the rendered PDF
+ * gets a blank rectangle where the map should be. A regular <img> always
+ * captures correctly.
+ */
+const snapshot = ref<string | null>(null)
+
+/**
  * Props
  */ 
 const { 
@@ -69,10 +78,32 @@ const loadMapbox = function() {
   // Wait for the first 'idle' event (everything painted, no in-flight tile
   // requests, no animations) rather than 'load' (style + initial tile batch
   // ready, but vector features may still be painting). 'idle' is strictly
-  // stronger and is what we want for a deterministic PDF.co snapshot.
+  // stronger.
   map.once('idle', () => {
+    // Map is rendered. Mount any slot children and let the consumer's @load
+    // handler attach markers / layers / heatmaps.
     loaded.value = true
     emit('load', { map, sdk: mapboxSDK } )
+
+    // Then wait for the *next* idle (after marker/layer draw settles) and
+    // capture the canvas to a PNG so the print pipeline can snapshot it.
+    // 500 ms timeout fallback in case nothing the consumer does triggers
+    // a redraw — we still need the wrapper to flip ready or the render
+    // pipeline waits forever.
+    let captured = false
+    const capture = () => {
+      if (captured) return
+      captured = true
+      requestAnimationFrame(() => {
+        try {
+          snapshot.value = map.getCanvas().toDataURL('image/png')
+        } catch (e) {
+          console.error('Map snapshot failed', e)
+        }
+      })
+    }
+    map.once('idle', capture)
+    setTimeout(capture, 500)
   })
 }
 
@@ -96,8 +127,9 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="MapBox">
-    <div ref="mapcontainer"></div>
+  <div class="MapBox" :data-mapbox-ready="snapshot ? 'true' : 'false'">
+    <div v-show="!snapshot" ref="mapcontainer"></div>
+    <img v-if="snapshot" :src="snapshot" alt="" class="MapBox__snapshot" />
     <slot v-if="loaded" />
   </div>
 </template>
@@ -105,10 +137,16 @@ onUnmounted(() => {
 <style>
 .MapBox {
   width: 100% !important;
-  height: 100% !important;  
+  height: 100% !important;
 }
 .mapboxgl-map {
   width: 100% !important;
   height: 100% !important;
+}
+.MapBox__snapshot {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
 }
 </style>


### PR DESCRIPTION
## Summary

Today's Gotenberg test render of De Veiling 38 (10 pages, 2.5 MB PDF, see chat) showed three chapters with **empty white space where the Mapbox map should be**: LocationChapter, ConstructionYearChapter, IncidentsChapter. Only the Mapbox attribution text rendered. Legends and chapter layouts rendered correctly — purely a WebGL → print problem.

**Root cause:** headless Chrome's print pipeline doesn't reliably capture WebGL canvases. Known footgun, known fix.

**Fix:** after the map settles, capture the canvas via `toDataURL('image/png')` and swap the live `<canvas>` for an `<img>`. `preserveDrawingBuffer: true` was already set on Map construction so `toDataURL` works without extra setup.

## Sequence

1. `map.once('idle')` → map is rendered (style + initial tiles)
2. `emit('load')` + `loaded=true` → consumer's `@load` handler runs (markers, layers, heatmaps) and the slot mounts
3. `map.once('idle')` again → marker/layer redraw has settled (with a **500 ms `setTimeout` fallback** in case the consumer didn't trigger any redraw — wrapper still needs to flip ready or rendering hangs)
4. `requestAnimationFrame()` → one paint frame to ensure the canvas is fully drawn before we read pixels
5. `snapshot.value = canvas.toDataURL(...)` → template swaps to `<img>`, wrapper sets `data-mapbox-ready=\"true\"`

## Recommended Gotenberg `waitForExpression`

The wrapper now exposes `data-mapbox-ready=\"true|false\"` so the headless renderer can wait on it alongside the existing `data-pdf-ready` signal:

```js
document.documentElement.dataset.pdfReady === \"true\" &&
  !document.querySelector('.MapBox[data-mapbox-ready=\"false\"]')
```

Returns `true` when data is loaded AND every MapBox instance has snapshotted. With no `.MapBox` instances on the page (chapter `v-if`'d out), the selector returns null and the expression remains true — graceful.

## Browser-side behavior

In a non-print browser context the snapshot still happens, which means the live map \"freezes\" into a still after first idle. The report is non-interactive anyway (no zoom / pan UX), so this is invisible to users.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [ ] **End-to-end Gotenberg verification** (requires this to be deployed to `report.fundermaps.com`):

  ```
  curl -X POST \\
    --form 'url=https://report.fundermaps.com/NL.IMBAG.PAND.0018100000044244' \\
    --form 'waitForExpression=document.documentElement.dataset.pdfReady === \"true\" && !document.querySelector(\".MapBox[data-mapbox-ready=\\\"false\\\"]\")' \\
    --form 'preferCssPageSize=true' \\
    --form 'printBackground=true' \\
    --form 'emulatedMediaType=print' \\
    --max-time 120 \\
    -o /tmp/gotenberg-test.pdf \\
    https://orca-app-wxi4e.ondigitalocean.app/forms/chromium/convert/url
  ```

  Page 3 (Locatie) should now show a building map; page 5 (Bouwjaar) a neighborhood construction-year heat map; page 8 (Incidenten) the KCAF density map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)