### PR TITLE
fix(report): two PDF cosmetic fixes — dedupe Volgende stappen + align reliability heading

### DIFF
--- a/src/components/Print/Chapters/FoundationRiskChapter.vue
+++ b/src/components/Print/Chapters/FoundationRiskChapter.vue
@@ -124,7 +124,7 @@ const graphData = computed(() => {
         </p>
         <p>
           Bij elk risico staat een categorie van A (laagste) tot E (hoogste) en een betrouwbaarheid
-          (Vastgesteld, Afgeleid of Modelmatig). Zie het hoofdstuk Hoe leest u dit rapport? voor de
+          (Vastgesteld, Afgeleid of Indicatief). Zie het hoofdstuk Hoe leest u dit rapport? voor de
           uitleg van beide. Onderaan dit hoofdstuk ziet u hoe uw pand zich verhoudt tot de panden in
           uw wijk.
         </p>
@@ -208,7 +208,13 @@ const graphData = computed(() => {
             </p>
           </div>
         </div>
-        <RiskNextSteps :level="fieldsWithDataAndIcons.dewateringDepthRisk?.icon" />
+        <!--
+          Volgende stappen for the dewateringDepth topic is rendered once
+          at the end of the Verschilzakking sub-section below — it covers
+          both Optrekkend vocht and Verschilzakking since they share the
+          same risk source (dewateringDepthRisk) and would otherwise
+          render identical closer copy back-to-back.
+        -->
       </div>
       <div v-if="fieldsWithDataAndIcons.dewateringDepthRisk?.icon" class="risk break-inside-avoid space-y-5">
         <div class="space-y-2">

--- a/src/components/Print/ReportGuide.vue
+++ b/src/components/Print/ReportGuide.vue
@@ -50,8 +50,8 @@ import Chapter from '@/components/Print/Chapter.vue'
             omdat vergelijkbare constructies en omstandigheden gelden.
           </li>
           <li>
-            <strong>Modelmatig (indicatief):</strong> Er zijn geen gegevens van dit pand of de
-            omliggende panden. De uitkomst is een modelinschatting met een lagere betrouwbaarheid.
+            <strong>Indicatief:</strong> Er zijn geen gegevens van dit pand of de omliggende panden.
+            De uitkomst is een modelinschatting met een lagere betrouwbaarheid.
           </li>
         </ul>
       </div>

--- a/src/views/PDF.vue
+++ b/src/views/PDF.vue
@@ -244,7 +244,7 @@ onUnmounted(() => {
           Dit funderingsrisicorapport is opgesteld op basis van beschikbare gegevens, metingen, modelanalyses en externe bronnen die op het moment van samenstelling beschikbaar waren. De gebruikte informatie is deels afkomstig van derden en/of berekend met behulp van algoritmen en risicomodellen. Waar mogelijk zijn deze gegevens aangevuld met locatiegerichte onderzoeksresultaten.
         </p>
         <p>
-          De in dit rapport opgenomen funderingstypen en risico-indicaties zijn bedoeld als risicosignalering. Wanneer de betrouwbaarheid als modelmatig (indicatief) is aangeduid, betreft het een globale inschatting op basis van generieke data. Deze gegevens geven geen garantie voor de daadwerkelijke staat van het pand en vormen geen vervanging van een technisch funderingsonderzoek op locatie.
+          De in dit rapport opgenomen funderingstypen en risico-indicaties zijn bedoeld als risicosignalering. Wanneer de betrouwbaarheid als indicatief is aangeduid, betreft het een globale modelinschatting op basis van generieke data. Deze gegevens geven geen garantie voor de daadwerkelijke staat van het pand en vormen geen vervanging van een technisch funderingsonderzoek op locatie.
         </p>
         <p>
           De betrouwbaarheid van het risicoprofiel verschilt per pand en is afhankelijk van de beschikbaarheid en kwaliteit van onderliggende data. Aanduidingen als vastgesteld, afgeleid of indicatief verwijzen naar deze mate van betrouwbaarheid.


### PR DESCRIPTION
## Summary

Two issues spotted in today's Gotenberg test render of De Veiling 38 (post-#46):

### 1. Duplicate Volgende stappen on page 6

`FoundationRiskChapter` renders **Optrekkend vocht** and **Verschilzakking** as two sub-sections, but both gate on the same `dewateringDepthRisk` value — so they always show the same risk level, same reliability, and (after `RiskNextSteps` in #43) the **same closer copy printed back-to-back word-for-word**. Reads like a copy mistake.

Removed the closer from Optrekkend vocht; the closer at the end of Verschilzakking now acts as the shared closer for the dewateringDepth topic chunk. Both sub-sections always render together (same `v-if` gate), so this is safe — there's no path where vocht renders without verschilzakking. **Drystand** and **Bacteriële aantasting** are unchanged — each gated on their own distinct risk source.

### 2. \"Modelmatig\" labels didn't match the data labels

`ReportGuide` listed the third reliability tier as **\"Modelmatig (indicatief)\"** in bold, but every chapter actually prints **\"Indicatief\"** because that's the `EReliability` label (`src/datastructures/enums/EReliability.ts` — `Indicative=0` → `\"Indicatief\"`). The customer read the glossary, never saw the bold term again, and had to mentally translate.

Aligned the bold heading to `Indicatief` so the glossary term matches what appears in chapters. Body keeps `modelinschatting` so the model-based reasoning is still surfaced. Also updated two adjacent references:
- `FoundationRiskChapter.vue:127` — the chapter-intro pointer back to the glossary (added in #44)
- `PDF.vue:247` — disclaimer prose (\"als modelmatig (indicatief) is aangeduid\" → \"als indicatief is aangeduid\")

Left `FacadeReviewChapter.vue:142` alone — it uses \"modelmatige risicobeoordelingen\" as an adjective describing the upstream technique, not as a tier label.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vite build` clean
- [x] `eslint src/` clean
- [x] Only legitimate adjective use of \"modelmatig\" remains (FacadeReviewChapter); zero remaining label/heading uses
- [ ] Re-render De Veiling 38 via Gotenberg after deploy: page 6 should show two risk sub-sections (Optrekkend vocht, Verschilzakking) with one Volgende stappen at the end; page 2 ReportGuide should bold-label \"Indicatief\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)