### PR TITLE
chore(auth): switch from Authorization: AuthKey to Bearer

### DIFF
--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -4,8 +4,8 @@ import { trimLeadingChar, trimTrailingChar } from "@/utils/string"
 // Report is opaque: only ever rendered by pdf.co for PDF generation.
 // There is no user session and no login UI. Auth is a single static
 // API key baked in at build time via VITE_AUTH_KEY, sent as
-// `Authorization: AuthKey fmsk.xxx` (the format the TS API's
-// authMiddleware expects).
+// `Authorization: Bearer fmsk.xxx` — same shape as FunderMapsWebservice,
+// the only API-key delivery the TS API accepts.
 const apiKey: string | null = import.meta.env.VITE_AUTH_KEY || null
 
 export const hasAPIKey = (): boolean => apiKey !== null && apiKey.length !== 0
@@ -29,7 +29,7 @@ const makeCall = async ({ endpoint, method = 'GET', body }: CallOptions): Promis
       method,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `AuthKey ${apiKey}`,
+        'Authorization': `Bearer ${apiKey}`,
       },
       ...(body !== undefined && { body: JSON.stringify(body) }),
     }


### PR DESCRIPTION
## Summary

FunderMapsApi standardizes API-key delivery on \`Authorization: Bearer fmsk.…\` (matches FunderMapsWebservice, which already removed both \`Authorization: AuthKey\` and \`X-API-Key\` in \`9485134\`/\`257d98e\`). This is the only remaining FunderMaps caller still using the AuthKey shape — flip it so both API surfaces speak the same auth header.

\`VITE_AUTH_KEY\` env var unchanged. The key itself is unchanged (still \`fmsk.xxx\`). Just the header name flips from \`AuthKey\` to \`Bearer\`.

## Coordination

Stacks with the API-side cleanup that drops the legacy header parsers (FunderMapsApi PR #49, currently being amended to strip \`X-API-Key\` + \`AuthKey\`). Either repo can merge first while the API still accepts both shapes; once the API cleanup ships, \`Bearer\` becomes the only working option.

## Test plan

- [x] \`vue-tsc --noEmit\` clean
- [ ] Build the report container, render a known building, confirm 200 against the prod API (the local FunderMaps dev guest can't do a full PDF render — pdf.co needs a public URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)